### PR TITLE
Pingdom Status Check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,19 @@ jobs:
       - run: npm install
       - run: npm run deploy
 
+  test-deploy:
+    docker: 
+      - image: trieloff/githop:node8
+    steps:
+      - checkout
+      - run: wsk property set --apihost runtime.adobe.io
+      - run: wsk property set --auth $WSK_AUTH
+      - run: wsk property set --namespace helix
+      - run: npm install
+      - run: npm run test-deploy
+      - run: curl --fail -X GET https://adobeioruntime.net/api/v1/web/helix/default/publish-test
+
+
   build:
     executor: node8
 
@@ -104,6 +117,9 @@ workflows:
   build:
     jobs:
     - build
+    - test-deploy:
+        requires:
+        - build
     # the publish-pre-release jobs needs a $NPM_TOKEN environment to be setup and also have a
     # valid SSH_KEY added for the `github.com` host.
     - publish-pre-release:
@@ -115,6 +131,7 @@ workflows:
             only: master_disabled
     - deploy:
         requires:
+        - test-deploy
         - build
         filters:
           branches:

--- a/index.js
+++ b/index.js
@@ -9,11 +9,24 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+// log the date to get the response time
+const start = Date.now();
 const publish = require('./src/publish');
 
-/* eslint-disable no-console */
-/* eslint-disable no-unreachable */
 async function main(params) {
+  // eslint-disable-next-line no-underscore-dangle
+  if (params && params.__ow_method && params.__ow_method === 'get') {
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+      body: `<pingdom_http_custom_check>
+      <status>OK</status>
+      <response_time>${Math.abs(Date.now() - start) / 1000}</response_time>
+  </pingdom_http_custom_check>`,
+    };
+  }
   const result = await publish(
     params.configuration,
     params.service,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "postversion": "git push origin master --follow-tags",
     "zip": "npm ls --prod --parseable | grep node_modules | sed -e 's/.*node_modules/node_modules/' | xargs zip publish.zip -r src layouts package.json index.js",
     "deploy": "npm run zip && wsk action update publish publish.zip --kind nodejs:8 --web true --web-secure false --timeout 60000",
+    "test-deploy": "npm run zip && wsk action update publish-test publish.zip --kind nodejs:8 --web true --web-secure false --timeout 60000",
     "delete-git-tag": "git tag -d v$npm_package_version && git push origin :v$npm_package_version"
   },
   "repository": {

--- a/test/integration.js
+++ b/test/integration.js
@@ -120,4 +120,11 @@ describe('Integration Test', () => {
     const res = await main(params);
     assert.equal(res.statusCode, 400);
   }).timeout(60000);
+
+  it('Get valid status report', async () => {
+    const res = await main({ __ow_method: 'get' });
+
+    assert.equal(res.statusCode, 200);
+    assert.ok(res.body.match(/<status>OK<\/status>/));
+  });
 });


### PR DESCRIPTION
Implements a custom status check for Pingdom and fixes #15 

To make deployments more robust, I'm deploying to a test action first and check if https://adobeioruntime.net/api/v1/web/helix/default/publish-test gives a status code of 200 for GET requests. That URL can also be used to preview the status check.