### PR TITLE
Refactor fixes & Redirect Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ This microservice sets up a Fastly service config so that it can be used for Pro
   - Adobe I/O Runtime
   - GitHub
   - all proxy strains from `helix-config.yaml`
+- setting up redirect rules
+  - request conditions
+  - `X-Location` headers
+  - code that detects `X-Location` headers and turns them into `301` redirects
 
 There are a number of important tasks involved in publishing that it does not do:
 

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -677,7 +677,7 @@ sub vcl_recv {
   # X-Location gets set by Helix's redirect logic inside the FASTLY recv block
   # that will get injected above.
   if (req.http.X-Location) {
-    error 301 "Redirect"
+    error 301 "Redirect";
   }
 
   # TODO: Do we even want to set a regular origin as default? Possibly set one

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1010,7 +1010,7 @@ sub vcl_error {
   if (obj.status == 301 && req.http.X-Location) {
     set obj.http.Content-Type = "text/html";
     set obj.http.Location = req.http.X-Location;
-    synthetic "Moved Permanently";
+    synthetic "Moved permanently <a href='" + req.http.X-Location+ "'>" + req.http.X-Location + "</a>";
     return(deliver);
   }
   call hlx_error_errors;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -533,7 +533,8 @@ sub hlx_type_image {
   call hlx_ref;
   call hlx_root_path;
 
-  declare local var.dir STRING; #directory name
+  declare local var.dir STRING; # directory name
+  declare local var.path STRING; # full path
   if (req.http.X-Dirname) {
     # set root path based on strain-specific dirname (strips away strain root)
     set var.dir = req.http.X-Root-Path + req.http.X-Dirname;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -941,6 +941,8 @@ sub vcl_miss {
   set req.http.X-Trace = req.http.X-Trace + "; vcl_miss";
 #FASTLY miss
 
+  call hlx_set_from_edge;
+
   call hlx_bereq;
 
   return(fetch);
@@ -949,6 +951,8 @@ sub vcl_miss {
 sub vcl_pass {
   set req.http.X-Trace = req.http.X-Trace + "; vcl_pass";
 #FASTLY pass
+
+  call hlx_set_from_edge;
 
   call hlx_bereq;
 

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1007,7 +1007,7 @@ sub vcl_error {
   set req.http.X-Trace = req.http.X-Trace + "; vcl_error";
 #FASTLY error
 
-  if (obj.status == 301) {
+  if (obj.status == 301 && req.http.X-Location) {
     set obj.http.Content-Type = "text/html";
     set obj.http.Location = req.http.X-Location;
     synthetic "Moved Permanently";

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -671,7 +671,6 @@ sub vcl_recv {
     set req.http.X-Trace = req.http.X-Trace + "; RESTART; vcl_recv";
   }
 
-  call hlx_set_from_edge;
   call hlx_recv_init;
 
 #FASTLY recv

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -104,7 +104,7 @@ sub hlx_recv_init {
   }
 
   # Check/clear X-From-Edge header
-  call hlx_check_from_edge
+  call hlx_check_from_edge;
 
   # Set original URL, so that we can log it afterwards.
   set req.http.X-Orig-URL = req.url;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -533,6 +533,7 @@ sub hlx_type_image {
   call hlx_ref;
   call hlx_root_path;
 
+  declare local var.dir STRING; #directory name
   if (req.http.X-Dirname) {
     # set root path based on strain-specific dirname (strips away strain root)
     set var.dir = req.http.X-Root-Path + req.http.X-Dirname;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -727,6 +727,8 @@ sub vcl_recv {
     call hlx_type_redirect;
   } elsif (req.http.X-Request-Type == "Embed") { 
     call hlx_type_embed;
+  } elseif (req.http.X-Request-Type == "Image") {
+    call hlx_type_image;
   } else {
     call hlx_type_pipeline;
   }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "mocha-junit-reporter": "^1.17.0",
     "mocha-parallel-tests": "^2.0.3",
     "nyc": "^13.3.0",
+    "request-promise-native": "^1.0.7",
     "sinon": "^7.2.3"
   },
   "dependencies": {

--- a/src/fastly/redirects,js
+++ b/src/fastly/redirects,js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const { pattern2vcl, condition } = require('./vcl-utils');
+
+function listredirects(strains) {
+  const redirectingstrains = strains.filter(strain => strain.redirects.length);
+  // go over all strains (that have redirects)
+  redirectingstrains.reduce((p, { name, redirects }) => {
+    // go over all redirects per strain
+    redirects.reduce((q, redirect) => {
+      // collect a new from, to, name tuple
+      q.push({
+        from: redirect.from,
+        to: redirect.to,
+        strain: name
+      });
+      return q;
+    }, p);
+    return p;
+  }, []);
+}
+
+function updateredirects(fastly, version, strains) {
+  const redirects = listredirects(strains).map(({from, to, strain}) => ({
+    condition: condition(from, strain),
+    expression: pattern2vcl(to),
+  }));
+
+  const update = fastly.headers.update(
+    version, 
+    'REQUEST', 
+    'Created by helix-publish for Redirects', 
+    'hlx-pub-redirect', 
+    'set', 
+    'http.X-Location', 
+    request);
+
+  return update(...redirects);
+}
+
+module.exports = {
+  listredirects, updateredirects
+}

--- a/src/fastly/redirects.js
+++ b/src/fastly/redirects.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe. All rights reserved.
+ * Copyright 2018 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -12,16 +12,16 @@
 const { pattern2vcl, condition } = require('./vcl-utils');
 
 function listredirects(strains) {
-  const redirectingstrains = strains.filter(strain => strain.redirects.length);
+  const redirectingstrains = strains.getByFilter(strain => strain.redirects.length);
   // go over all strains (that have redirects)
-  redirectingstrains.reduce((p, { name, redirects }) => {
+  return redirectingstrains.reduce((p, { name, redirects }) => {
     // go over all redirects per strain
     redirects.reduce((q, redirect) => {
       // collect a new from, to, name tuple
       q.push({
         from: redirect.from,
         to: redirect.to,
-        strain: name
+        strain: name,
       });
       return q;
     }, p);
@@ -29,24 +29,25 @@ function listredirects(strains) {
   }, []);
 }
 
-function updateredirects(fastly, version, strains) {
-  const redirects = listredirects(strains).map(({from, to, strain}) => ({
+function updatestrains(fastly, version, strains) {
+  const redirects = listredirects(strains).map(({ from, to, strain }) => ({
     condition: condition(from, strain),
     expression: pattern2vcl(to),
   }));
 
   const update = fastly.headers.update(
-    version, 
-    'REQUEST', 
-    'Created by helix-publish for Redirects', 
-    'hlx-pub-redirect', 
-    'set', 
-    'http.X-Location', 
-    request);
+    version,
+    'REQUEST',
+    'Created by helix-publish for Redirects',
+    'hlx-pub-redirect',
+    'set',
+    'http.X-Location',
+    'request',
+  );
 
   return update(...redirects);
 }
 
 module.exports = {
-  listredirects, updateredirects
-}
+  listredirects, updatestrains,
+};

--- a/src/fastly/vcl-utils.js
+++ b/src/fastly/vcl-utils.js
@@ -209,7 +209,26 @@ function xversion(configVersion, cliVersion, revision = 'online') {
   return retvcl;
 }
 
+/**
+ * Turns regex-like replacement patterns into valid VCL statements, e.g. `/foo/$1.html` becomes
+ * `"/foo/" + re.group.1 + ".html"`
+ * @param {string} pattern - a replacement pattern that may include regex-like references like `$1`
+ */
+function pattern2vcl(pattern) {
+  return `"${pattern.replace(/\$([0-9])/g, '" + re.group.$1 + "')}"`;
+}
+
+/**
+ * Turns a regex-pattern (on the full URL, if it starts with `https://`, on the path and QS only, otherwise)
+ * into a valid VCL condition that also checks for a matching X-Strain header value.
+ * @param {string} pattern - a regex-like pattern
+ * @param {string} strain - name of the strain
+ */
+function condition(pattern, strain) {
+  const varname = pattern.match(/^https:\/\//) ? '("https://" + req.http.host + req.url)' : 'req.url';
+  return `req.http.X-Strain == "${strain}" && ${varname} ~ "${pattern}"`;
+}
 
 module.exports = {
-  resolve, reset, parameters, xversion, regexp, writevcl,
+  resolve, reset, parameters, xversion, regexp, writevcl, pattern2vcl, condition,
 };

--- a/src/publish.js
+++ b/src/publish.js
@@ -15,6 +15,7 @@ const initfastly = require('@adobe/fastly-native-promises');
 const backends = require('./fastly/backends');
 const vcl = require('./fastly/vcl');
 const dictionaries = require('./fastly/dictionaries');
+const redirects = require('./fastly/redirects');
 
 async function publish(configuration, service, token, version) {
   if (!(!!token && !!service)) {
@@ -36,6 +37,7 @@ async function publish(configuration, service, token, version) {
       backends.updatestrains(fastly, version, config.strains),
       vcl.init(fastly, version),
       vcl.updatestrains(fastly, version, config.strains),
+      redirects.updatestrains(fastly, version, config.strains),
       dictionaries.init(
         fastly,
         version,

--- a/test/fixtures/full.yaml
+++ b/test/fixtures/full.yaml
@@ -20,9 +20,13 @@ definitions:
       code: *myrepo
       content: *myrepo
       static: *myrepo
+      redirects:
+        - from: /foo/(.*)
+          to: /bar/$1
 
 strains:
-  default: *basestrain
+  default: 
+    <<: *basestrain
 
   adhoc:
     <<: *basestrain
@@ -38,6 +42,9 @@ strains:
       ref: master
       owner: adobe
     directoryIndex: readme.html
+    redirects:
+      - from: /(.*).php
+        to: /$1.html
 
   pipeline:
     <<: *basestrain

--- a/test/integration.js
+++ b/test/integration.js
@@ -101,7 +101,7 @@ describe('Integration Test', () => {
     assert.deepStrictEqual(res, {
       body: {
         status: 'published',
-        completed: 5,
+        completed: 6,
       },
       statusCode: 200,
     });

--- a/test/integration.js
+++ b/test/integration.js
@@ -11,6 +11,7 @@
  */
 const { condit } = require('@adobe/helix-testutils');
 const assert = require('assert');
+const request = require('request-promise-native');
 const { main } = require('../index');
 /* eslint-env mocha */
 
@@ -104,6 +105,20 @@ describe('Integration Test', () => {
         completed: 6,
       },
       statusCode: 200,
+    });
+
+    const valid = await request.get(
+      `https://api.fastly.com/service/${process.env.HLX_FASTLY_NAMESPACE}/version/1/validate`,
+      {
+        headers: {
+          'Fastly-Key': process.env.HLX_FASTLY_AUTH,
+          accept: 'application/json',
+        },
+        json: true,
+      },
+    );
+    assert.deepStrictEqual(valid, {
+      status: 'ok', errors: [], messages: [], warnings: [], msg: null,
     });
   }).timeout(60000);
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -60,6 +60,12 @@ const config = {
         perf: { device: '', location: '', connection: '' },
         urls: ['https://www.project-helix.io/cli'],
         url: 'https://www.project-helix.io/cli',
+        redirects: [
+          {
+            from: '(.*)\\.php',
+            to: '$1.html',
+          },
+        ],
       },
     },
   },

--- a/test/integration.js
+++ b/test/integration.js
@@ -108,7 +108,7 @@ describe('Integration Test', () => {
     });
 
     const valid = await request.get(
-      `https://api.fastly.com/service/${process.env.HLX_FASTLY_NAMESPACE}/version/1/validate`,
+      `https://api.fastly.com/service/${process.env.HLX_FASTLY_NAMESPACE}/version/${process.env.VERSION_NUM}/validate`,
       {
         headers: {
           'Fastly-Key': process.env.HLX_FASTLY_AUTH,

--- a/test/redirects.test.js
+++ b/test/redirects.test.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const assert = require('assert');
+const sinon = require('sinon');
+const path = require('path');
+const { HelixConfig } = require('@adobe/helix-shared');
+const { updatestrains } = require('../src/fastly/redirects');
+
+/* eslint-env mocha */
+
+describe('Testing redirects.js', () => {
+  it('#updatestrains/full', async () => {
+    const fakeupdate = sinon.fake();
+
+    const fastly = {
+      headers: {
+        update: () => fakeupdate,
+      },
+    };
+
+    const config = await new HelixConfig()
+      .withConfigPath(path.resolve(__dirname, 'fixtures/full.yaml'))
+      .init();
+
+    await updatestrains(fastly, 1, config.strains);
+
+    assert.ok(fakeupdate.calledOnce);
+    assert.deepStrictEqual(fakeupdate.lastCall.args, [{
+      condition: 'req.http.X-Strain == "default" && req.url ~ "\\/foo\\/(.*)"',
+      expression: '"/bar/" + re.group.1 + ""',
+    },
+    {
+      condition: 'req.http.X-Strain == "adhoc" && req.url ~ "\\/foo\\/(.*)"',
+      expression: '"/bar/" + re.group.1 + ""',
+    },
+    {
+      condition: 'req.http.X-Strain == "client" && req.url ~ "\\/(.*).php"',
+      expression: '"/" + re.group.1 + ".html"',
+    },
+    {
+      condition: 'req.http.X-Strain == "pipeline" && req.url ~ "\\/foo\\/(.*)"',
+      expression: '"/bar/" + re.group.1 + ""',
+    }]);
+  });
+});

--- a/test/vcl-utils.test.js
+++ b/test/vcl-utils.test.js
@@ -89,6 +89,6 @@ describe('Testing vcl-utils.js', () => {
 
   it('#condition', () => {
     assert.equal(utils.condition('/old/(.*)', 'default'), 'req.http.X-Strain == "default" && req.url ~ "/old/(.*)"');
-    assert.equal(utils.condition('https://(.*)\.adobe.io', 'staging'), 'req.http.X-Strain == "staging" && ("https://" + req.http.host + req.url) ~ "https://(.*).adobe.io"');
+    assert.equal(utils.condition('https://(.*).adobe.io', 'staging'), 'req.http.X-Strain == "staging" && ("https://" + req.http.host + req.url) ~ "https://(.*).adobe.io"');
   });
 });

--- a/test/vcl-utils.test.js
+++ b/test/vcl-utils.test.js
@@ -79,4 +79,16 @@ describe('Testing vcl-utils.js', () => {
   it('#parameters/full', parameterstest('full'));
   it('#parameters/noparams', parameterstest('noparams'));
   it('#parameters/manyparams', parameterstest('manyparams'));
+
+  it('#pattern2vcl', () => {
+    assert.equal(utils.pattern2vcl('/foo/bar'), '"/foo/bar"');
+    assert.equal(utils.pattern2vcl('/foo/$1.html'), '"/foo/" + re.group.1 + ".html"');
+    assert.equal(utils.pattern2vcl('/foo/$1/bar/$2.html'), '"/foo/" + re.group.1 + "/bar/" + re.group.2 + ".html"');
+    assert.equal(utils.pattern2vcl('/foo/$1/bar/$2.$3'), '"/foo/" + re.group.1 + "/bar/" + re.group.2 + "." + re.group.3 + ""');
+  });
+
+  it('#condition', () => {
+    assert.equal(utils.condition('/old/(.*)', 'default'), 'req.http.X-Strain == "default" && req.url ~ "/old/(.*)"');
+    assert.equal(utils.condition('https://(.*)\.adobe.io', 'staging'), 'req.http.X-Strain == "staging" && ("https://" + req.http.host + req.url) ~ "https://(.*).adobe.io"');
+  });
 });


### PR DESCRIPTION
This is a cumulative PR for
- #30 (redirects)
- #32 (images)
- #33 (`X-From-Edge`)

and amends/obsoletes
- #7 (VCL refactor)
- #27 (redirect drafts)

The tests now ensure that Fastly accepts the VCL we upload, which is a great help. 😉