### PR TITLE
Enable Better Caching for Static Resources

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -549,9 +549,10 @@ sub hlx_fetch_static {
 }
 
 sub hlx_deliver_static {
-  set req.http.X-Trace = req.http.X-Trace + "; hlx_deliver_static";
+  set resp.http.X-Static-Trace = req.http.X-Trace + "; hlx_deliver_static";
+  set resp.http.X-Static-Trace = set resp.http.X-Static-Trace + "[type=" + req.http.X-Request-Type + ", status=" + resp.status + "]";
   if (req.http.X-Request-Type == "Static-ESI" && resp.status == 200) {
-    set req.http.X-Trace = req.http.X-Trace + "(esi)";
+    set resp.http.X-Trace = resp.http.X-Trace + "(esi)";
     # Get the ETag response header and use it to construct a stable URL
     declare local var.ext STRING;
 
@@ -1071,9 +1072,9 @@ sub vcl_deliver {
   set req.http.X-Trace = req.http.X-Trace + "; vcl_deliver";
 #FASTLY deliver
 
-  call hlx_deliver_static;
-
   call hlx_headers_deliver;
+
+  call hlx_deliver_static;
 
   # only set the strain cookie for sticky strains
   # and only do it for the Adobe I/O Runtime backend

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -558,7 +558,10 @@ sub hlx_deliver_static {
     restart;
   } elsif (req.http.X-Request-Type == "Static-ESI") {
     # Get the ETag response header and use it to construct a stable URL
-    synthetic regsub(req.http.X-Orig-URL, ".esi$", ".hlx_" + digest.hash_sha1(resp.http.ETag));
+    declare local var.ext STRING;
+
+    set var.ext = ".hlx_" + digest.hash_sha1(resp.http.ETag);
+    synthetic regsub(req.http.X-Orig-URL, ".esi$", var.ext);
     return(deliver);
   }
 }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -535,14 +535,15 @@ sub hlx_fetch_static {
     set var.ext = ".hlx_" + digest.hash_sha1(beresp.http.ETag);
 
     if (re.group.2 == var.ext) {
-      # tell the browser to keep them forever
       set beresp.http.Cache-Control = "max-age=31622400,immutable"; # keep it for a year in the browser;
-      set beresp.http.Surrogate-Control = "max-age=3600"; # but only for an hour in the shared cache
-                                                          # to limit cache poisioning
+      set beresp.http.Surrogate-Control = "max-age=31622400,immutable";
       set beresp.cacheable = true;
-      set beresp.ttl = 3600s;
+      set beresp.ttl = 31622400s;
     } else {
+      set beresp.ttl = 300s;
+      error 404 "Invalid";
       set beresp.http.X-Trace = "etag=" + beresp.http.ETag + "; ext=" + var.ext;
+
     }
     return(deliver);
   }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -499,12 +499,12 @@ sub hlx_fetch_static {
   set req.http.X-Trace = req.http.X-Trace + "; hlx_fetch_static";
 
   if (req.http.X-Request-Type == "Static-ESI" && beresp.status == 200) {
-    set resp.http.X-Static-Trace = resp.http.X-Static-Trace + "(esi)";
+    set req.http.X-Trace = req.http.X-Trace + "(esi)";
     # Get the ETag response header and use it to construct a stable URL
     declare local var.ext STRING;
 
     set var.ext = ".hlx_" + digest.hash_sha1(beresp.http.ETag);
-    set resp.http.X-Static-Trace = resp.http.X-Static-Trace + "[url=" + req.http.X-Orig-URL + ", ext=" + var.ext + "]";
+    set req.http.X-Trace = req.http.X-Trace + "[url=" + req.http.X-Orig-URL + ", ext=" + var.ext + "]";
     set req.http.X-Location = regsub(req.http.X-Orig-URL, ".esi$", var.ext);
     error 303 "ESI"; 
   }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -452,10 +452,12 @@ sub hlx_type_static {
   
   # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441
   if (req.http.X-Orig-URL ~ "^(.*)(.hlx_([0-9a-f]){20,40}$)") {
+    set req.http.X-Trace = req.http.X-Trace + "(immutable)";
     # and keep only the non-hashed part, i.e. everything before .hlx_
     set var.path = re.group.1;
-    set var.entry = re.group.2;
+    set var.entry = re.group.1;
   } else {
+    set req.http.X-Trace = req.http.X-Trace + "(normal)";
     # TODO: check for URL ending with `/` and look up index file
     set var.path = req.http.X-Orig-URL;
     set var.entry = req.http.X-Orig-URL;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -539,7 +539,7 @@ sub hlx_fetch_static {
     set var.ext = ".hlx_" + digest.hash_sha1(beresp.http.ETag);
 
     if (re.group.2 == var.ext) {
-      req.esi = true;
+      set req.esi = true;
       esi;
       set beresp.http.X-ESI = "processed(" + bereq.http.Accept-Encoding + ", " + req.esi + "," + req.http.X-From-Edge +")";
       set beresp.http.Cache-Control = "max-age=31622400,immutable"; # keep it for a year in the browser;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -499,11 +499,12 @@ sub hlx_type_redirect {
 
 sub hlx_fetch_static {
   set req.http.X-Trace = req.http.X-Trace + "; hlx_fetch_static";
+  declare local var.ext STRING;
 
   if (req.http.X-Request-Type == "Static-ESI" && beresp.status == 200) {
     set req.http.X-Trace = req.http.X-Trace + "(esi)";
     # Get the ETag response header and use it to construct a stable URL
-    declare local var.ext STRING;
+    
 
     set var.ext = ".hlx_" + digest.hash_sha1(beresp.http.ETag);
     set req.http.X-Trace = req.http.X-Trace + "[url=" + req.http.X-Orig-URL + ", ext=" + var.ext + "]";
@@ -514,7 +515,6 @@ sub hlx_fetch_static {
   if (req.http.X-Orig-URL ~ "^(.*)(.hlx_([0-9a-f]){20,40}$)") {
     set req.http.X-Trace = req.http.X-Trace + "(immutable)";
 
-    declare local var.ext STRING;
     set var.ext = ".hlx_" + digest.hash_sha1(beresp.http.ETag);
 
     if (req.group.2 == var.ext) {

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -136,7 +136,7 @@ sub hlx_recv_init {
   }
 
   # set X-Version initial value
-  set req.http.X-Version = regsub(req.vcl, "([^.]+)\.(\d+)_(\d+)-(.*)", "\2");
+  set req.http.X-Version = "static-esi" + regsub(req.vcl, "([^.]+)\.(\d+)_(\d+)-(.*)", "\2");
 
 }
 
@@ -298,6 +298,11 @@ sub hlx_github_static_root {
   if (!req.http.X-Github-Static-Root) {
     set req.http.X-Github-Static-Root = "/";
   }
+  if (req.http.X-Github-Static-Root) {
+    set req.http.X-Trace = req.http.X-Trace + "(" + req.http.X-Github-Static-Root + ")";
+  } else {
+    set req.http.X-Trace = req.http.X-Trace + "(none)";
+  }
 }
 
 # Gets the github static ref
@@ -418,6 +423,7 @@ sub hlx_type_static_esi {
     req.http.X-GitHub-Static-Owner + "/" +
     req.http.X-Github-Static-Repo + "/" +
     req.http.X-GitHub-Static-Ref + // no slash at the end, because the X-Orig-URL starts with one
+    ">" + req.http.X-Github-Static-Root + "<"
     regsub(req.http.X-Orig-URL, ".esi$", "");
 }
 

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -374,7 +374,7 @@ sub hlx_request_type {
     return;
   }
 
-  if (req.url.ext ~ "^(.*)(.hlx_([0-9a-f]){20,40}$)") {
+  if (req.url.ext ~ "^(hlx_([0-9a-f]){20,40}$)") {
     set req.http.X-Trace = req.http.X-Trace + "(immutable)";
     set req.http.X-Request-Type = "Static";
     return;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -556,7 +556,7 @@ sub hlx_deliver_static {
       set req.http.X-Request-Type = "Static";
     }
     restart;
-  } elsif (req.X-Request-Type == "Static-ESI") {
+  } elsif (req.http.X-Request-Type == "Static-ESI") {
     # Get the ETag response header and use it to construct a stable URL
     synthetic regsub(req.http.X-Orig-URL, ".esi$", ".hlx_" + digest.hash_sha1(resp.http.ETag));
     return(deliver);

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -419,7 +419,7 @@ sub hlx_type_static_esi {
     req.http.X-GitHub-Static-Owner + "/" +
     req.http.X-Github-Static-Repo + "/" +
     req.http.X-GitHub-Static-Ref + // no slash at the end, because the X-Orig-URL starts with one
-    ">" + req.http.X-Github-Static-Root + "<"
+    req.http.X-Github-Static-Root +
     regsub(req.http.X-Orig-URL, ".esi$", "");
 }
 
@@ -534,7 +534,7 @@ sub hlx_fetch_static {
 
 sub hlx_deliver_static {
   set req.http.X-Trace = req.http.X-Trace + "; hlx_deliver_static";
-  elsif (req.http.X-Request-Type == "Static-ESI" && resp.status == 200) {
+  if (req.http.X-Request-Type == "Static-ESI" && resp.status == 200) {
     set req.http.X-Trace = req.http.X-Trace + "(esi)";
     # Get the ETag response header and use it to construct a stable URL
     declare local var.ext STRING;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -524,6 +524,8 @@ sub hlx_fetch_static {
                                                           # to limit cache poisioning
       set beresp.cacheable = true;
       set beresp.ttl = 3600s;
+    } else {
+      set beresp.http.X-Trace = "etag=" + beresp.http.ETag + "; ext=" + var.ext;
     }
     return(deliver);
   }
@@ -558,8 +560,7 @@ sub hlx_fetch_static {
 }
 
 sub hlx_deliver_static {
-  set resp.http.X-Static-Trace = req.http.X-Trace + "; hlx_deliver_static";
-  set resp.http.X-Static-Trace = resp.http.X-Static-Trace + "[type=" + req.http.X-Request-Type + ", status=" + resp.status + "]";
+  set req.http.X-Trace = req.http.X-Trace + "; hlx_deliver_static";
   if (resp.http.X-Static == "Raw/Static" && resp.status == 307) {
     # This is done in `vcl_deliver` instead of `vcl_fetch` because of Fastly
     # clustering. Changes made to most `req` variables don't make it back to

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -136,7 +136,7 @@ sub hlx_recv_init {
   }
 
   # set X-Version initial value
-  set req.http.X-Version = "static-esi" + regsub(req.vcl, "([^.]+)\.(\d+)_(\d+)-(.*)", "\2");
+  set req.http.X-Version = regsub(req.vcl, "([^.]+)\.(\d+)_(\d+)-(.*)", "\2");
 
 }
 
@@ -1045,10 +1045,10 @@ sub hlx_bereq {
   if (req.backend == F_AdobeRuntime) {
     # set backend authentication
     set bereq.http.Authorization = table.lookup(secrets, "OPENWHISK_AUTH");
-
-    # making sure to get an uncompressed object for ESI
-    unset bereq.http.Accept-Encoding;
   }
+
+  # making sure to get an uncompressed object for ESI
+  unset bereq.http.Accept-Encoding;
 
   # Clean up all temporary request headers, since origins might be 3rd parties
   unset bereq.http.X-Orig-Url;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -404,7 +404,7 @@ sub hlx_request_type {
  * @header X-Orig-URL             the original (unmodified) URL, starting after hostname and port
  */
 sub hlx_type_static_esi {
-  set req.http.X-Trace = req.http.X-Trace + "; hlx_type_static(esi)";
+  set req.http.X-Trace = req.http.X-Trace + "; hlx_type_static_esi";
 
   set req.backend = F_GitHub;
 
@@ -1071,9 +1071,9 @@ sub vcl_deliver {
   set req.http.X-Trace = req.http.X-Trace + "; vcl_deliver";
 #FASTLY deliver
 
-  call hlx_headers_deliver;
-
   call hlx_deliver_static;
+
+  call hlx_headers_deliver;
 
   # only set the strain cookie for sticky strains
   # and only do it for the Adobe I/O Runtime backend

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -414,7 +414,7 @@ sub hlx_type_static_esi {
   call hlx_github_static_root;
 
   // https://raw.githubusercontent.com/trieloff/helix-demo/master/htdocs/index.js
-  set req.http.X-Backend-URL = 
+  set req.http.X-Backend-URL = "/" +
     req.http.X-GitHub-Static-Owner + "/" +
     req.http.X-Github-Static-Repo + "/" +
     req.http.X-GitHub-Static-Ref + // no slash at the end, because the X-Orig-URL starts with one

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -374,6 +374,12 @@ sub hlx_request_type {
     return;
   }
 
+  if (req.url.ext ~ "^(.*)(.hlx_([0-9a-f]){20,40}$)") {
+    set req.http.X-Trace = req.http.X-Trace + "(immutable)";
+    set req.http.X-Request-Type = "Static";
+    return;
+  }
+
   # Binary type images
   if (req.url.ext ~ "(?i)^(?:gif|png|jpe?g|webp)$") {
     set req.http.X-Trace = req.http.X-Trace + "(image)";

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -998,13 +998,9 @@ sub vcl_fetch {
     }
   }
 
-  if ( req.http.x-esi ) {
-    esi;
-  }
-
   call hlx_fetch_static;
 
-  if (beresp.http.X-ESI) {
+  if (beresp.http.X-ESI == "enabled" || req.http.x-esi) {
     esi;
   }
 
@@ -1051,7 +1047,7 @@ sub hlx_bereq {
   }
 
   # making sure to get an uncompressed object for ESI
-  if ( req.url.ext == "html" ) {
+  if ( req.url.ext == "html" || req.url.ext == "js" || req.url.ext == "css" ) {
     unset bereq.http.Accept-Encoding;
   }
 

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -377,6 +377,7 @@ sub hlx_request_type {
   if (req.url.ext ~ "^(hlx_([0-9a-f]){20,40}$)") {
     set req.http.X-Trace = req.http.X-Trace + "(immutable)";
     set req.http.X-Request-Type = "Static";
+    unset req.http.Accept-Encoding;
     return;
   }
 

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -403,7 +403,7 @@ sub hlx_request_type {
  * @header X-Orig-URL             the original (unmodified) URL, starting after hostname and port
  */
 sub hlx_type_static_esi {
-  set req.http.X-Trace = req.http.X-Trace + "; hlx_type_static";
+  set req.http.X-Trace = req.http.X-Trace + "; hlx_type_static(esi)";
 
   set req.backend = F_GitHub;
 
@@ -557,6 +557,7 @@ sub hlx_deliver_static {
     }
     restart;
   } elsif (req.http.X-Request-Type == "Static-ESI") {
+    set req.http.X-Trace = req.http.X-Trace + "(esi)";
     # Get the ETag response header and use it to construct a stable URL
     declare local var.ext STRING;
 

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -552,11 +552,12 @@ sub hlx_deliver_static {
   set resp.http.X-Static-Trace = req.http.X-Trace + "; hlx_deliver_static";
   set resp.http.X-Static-Trace = resp.http.X-Static-Trace + "[type=" + req.http.X-Request-Type + ", status=" + resp.status + "]";
   if (req.http.X-Request-Type == "Static-ESI" && resp.status == 200) {
-    set resp.http.X-Trace = resp.http.X-Trace + "(esi)";
+    set resp.http.X-Static-Trace = resp.http.X-Static-Trace + "(esi)";
     # Get the ETag response header and use it to construct a stable URL
     declare local var.ext STRING;
 
     set var.ext = ".hlx_" + digest.hash_sha1(resp.http.ETag);
+    set resp.http.X-Static-Trace = resp.http.X-Static-Trace + "[url=" + req.http.X-Orig-URL + ", ext=" + var.ext + "]";
     synthetic regsub(req.http.X-Orig-URL, ".esi$", var.ext);
     return(deliver);
   } elsif (resp.http.X-Static == "Raw/Static" && resp.status == 307) {

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -433,8 +433,8 @@ sub hlx_type_static_url {
   call hlx_github_static_root;
 
   # TODO: check for URL ending with `/` and look up index file
-  set var.path = regsub(req.http.X-Orig-URL, ".url$", "");
-  set var.entry = regsub(req.http.X-Orig-URL, ".url$", "");
+  set var.path = regsub(req.http.X-Orig-URL, ".(url|302)$", "");
+  set var.entry = regsub(req.http.X-Orig-URL, ".(url|302)$", "");
 
   set req.http.X-Action-Root = "/api/v1/web/" + table.lookup(secrets, "OPENWHISK_NAMESPACE") + "/default/hlx--static";
   set req.http.X-Backend-URL = req.http.X-Action-Root
@@ -449,7 +449,6 @@ sub hlx_type_static_url {
     + "&allow=" urlencode(req.http.X-Allow)
     + "&deny=" urlencode(req.http.X-Deny)
     + "&root=" + req.http.X-Github-Static-Root;
-    
 }
 
 /**

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -549,6 +549,7 @@ sub hlx_fetch_static {
       set req.esi = true;
       esi;
       set beresp.http.X-ESI = "processed(" + bereq.http.Accept-Encoding + ", " + req.esi + "," + req.http.X-From-Edge +")";
+      `set beresp.http.x-compress-hint = "on";` // so h2o compresses it on the way out
       set beresp.http.Cache-Control = "max-age=31622400,immutable"; # keep it for a year in the browser;
       set beresp.http.Surrogate-Control = "max-age=31622400,immutable";
       set beresp.cacheable = true;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -550,7 +550,7 @@ sub hlx_fetch_static {
 
 sub hlx_deliver_static {
   set resp.http.X-Static-Trace = req.http.X-Trace + "; hlx_deliver_static";
-  set resp.http.X-Static-Trace = set resp.http.X-Static-Trace + "[type=" + req.http.X-Request-Type + ", status=" + resp.status + "]";
+  set resp.http.X-Static-Trace = resp.http.X-Static-Trace + "[type=" + req.http.X-Request-Type + ", status=" + resp.status + "]";
   if (req.http.X-Request-Type == "Static-ESI" && resp.status == 200) {
     set resp.http.X-Trace = resp.http.X-Trace + "(esi)";
     # Get the ETag response header and use it to construct a stable URL

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -517,7 +517,7 @@ sub hlx_fetch_static {
 
     set var.ext = ".hlx_" + digest.hash_sha1(beresp.http.ETag);
 
-    if (req.group.2 == var.ext) {
+    if (re.group.2 == var.ext) {
       # tell the browser to keep them forever
       set beresp.http.Cache-Control = "max-age=31622400,immutable"; # keep it for a year in the browser;
       set beresp.http.Surrogate-Control = "max-age=3600"; # but only for an hour in the shared cache

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -539,8 +539,9 @@ sub hlx_fetch_static {
     set var.ext = ".hlx_" + digest.hash_sha1(beresp.http.ETag);
 
     if (re.group.2 == var.ext) {
+      req.esi = true;
       esi;
-      set beresp.http.X-ESI = "processed(" + bereq.http.Accept-Encoding + ")";
+      set beresp.http.X-ESI = "processed(" + bereq.http.Accept-Encoding + ", " + req.esi + "," + req.http.X-From-Edge +")";
       set beresp.http.Cache-Control = "max-age=31622400,immutable"; # keep it for a year in the browser;
       set beresp.http.Surrogate-Control = "max-age=31622400,immutable";
       set beresp.cacheable = true;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1192,6 +1192,7 @@ sub vcl_error {
   if (obj.status == 902 && req.http.X-Location) {
     set obj.http.Content-Type = "text/html";
     set obj.status = 302;
+    set obj.location = req.http.X-Location;
     synthetic "Found: <a href='" + req.http.X-Location+ "'>" + req.http.X-Location + "</a>";
     return(deliver);
   }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -298,11 +298,7 @@ sub hlx_github_static_root {
   if (!req.http.X-Github-Static-Root) {
     set req.http.X-Github-Static-Root = "/";
   }
-  if (req.http.X-Github-Static-Root) {
-    set req.http.X-Trace = req.http.X-Trace + "(" + req.http.X-Github-Static-Root + ")";
-  } else {
-    set req.http.X-Trace = req.http.X-Trace + "(none)";
-  }
+  set req.http.X-Trace = req.http.X-Trace + "(" + req.http.X-Github-Static-Root +  ")";
 }
 
 # Gets the github static ref
@@ -546,15 +542,19 @@ sub hlx_deliver_static {
       set req.http.X-Request-Type = "Redirect";
       set req.http.X-Backend-URL = re.group.1;
       set req.http.X-Static-Content-Type = resp.http.X-Content-Type;
+      set req.http.X-Trace = req.http.X-Trace + "(redirect)";
       restart;
     } else {
       set resp.status = 500;
       set resp.response = "Redirect to wrong hostname";
+      set req.http.X-Trace = req.http.X-Trace + "(redirect-error)";
     }
   } elsif ((resp.status == 404 || resp.status == 204) && !req.http.X-Disable-Static && req.restarts < 1) {
     # That was a miss. Let's try to restart, but only restart once
     set resp.http.X-Status = resp.status + "-Restart " + req.restarts;
     set resp.status = 404;
+    
+    set req.http.X-Trace = req.http.X-Trace + "(404)";
 
     if (req.http.X-Request-Type == "Static") {
       set req.http.X-Request-Type = "Dynamic";

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -417,7 +417,7 @@ sub hlx_type_static_esi {
   set req.http.X-Backend-URL = 
     req.http.X-GitHub-Static-Owner + "/" +
     req.http.X-Github-Static-Repo + "/" +
-    req.http.X-GitHub-Static-Ref + "/" +
+    req.http.X-GitHub-Static-Ref + // no slash at the end, because the X-Orig-URL starts with one
     regsub(req.http.X-Orig-URL, ".esi$", "");
 }
 

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -514,10 +514,10 @@ sub hlx_fetch_static {
     # Get the ETag response header and use it to construct a stable URL
     declare local var.ext STRING;
 
-    set var.ext = ".hlx_" + digest.hash_sha1(resp.http.ETag);
+    set var.ext = ".hlx_" + digest.hash_sha1(beresp.http.ETag);
     synthetic regsub(req.http.X-Orig-URL, ".esi$", var.ext);
     return(deliver);
-    
+
   } elsif (beresp.http.X-Static == "Raw/Static") {
     set req.http.X-Trace = req.http.X-Trace + "(raw)";
     if (beresp.status == 307) {

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -540,7 +540,7 @@ sub hlx_fetch_static {
 
     if (re.group.2 == var.ext) {
       esi;
-      set beresp.http.X-ESI = "processed";
+      set beresp.http.X-ESI = "processed(" + bereq.http.Accept-Encoding + ")";
       set beresp.http.Cache-Control = "max-age=31622400,immutable"; # keep it for a year in the browser;
       set beresp.http.Surrogate-Control = "max-age=31622400,immutable";
       set beresp.cacheable = true;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -499,9 +499,9 @@ sub hlx_fetch_static {
   # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441
   if (req.http.X-Orig-URL ~ "^(.*)(.hlx_([0-9a-f]){20,40}$)") {
     # tell the browser to keep them forever
-    set beresp.http.Cache-Control = "max-age=31622400" # keep it for a year in the browser;
-    set beresp.http.Surrogate-Control = "max-age=3600" # but only for an hour in the shared cache
-                                                       # to limit cache poisioning
+    set beresp.http.Cache-Control = "max-age=31622400"; # keep it for a year in the browser;
+    set beresp.http.Surrogate-Control = "max-age=3600"; # but only for an hour in the shared cache
+                                                        # to limit cache poisioning
     set beresp.cacheable = true;
     set beresp.ttl = 3600;
   }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -503,7 +503,7 @@ sub hlx_fetch_static {
     set beresp.http.Surrogate-Control = "max-age=3600"; # but only for an hour in the shared cache
                                                         # to limit cache poisioning
     set beresp.cacheable = true;
-    set beresp.ttl = 3600;
+    set beresp.ttl = 3600s;
   }
   if (beresp.http.X-Static == "Raw/Static") {
     if (beresp.status == 307) {

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -549,7 +549,7 @@ sub hlx_fetch_static {
       set req.esi = true;
       esi;
       set beresp.http.X-ESI = "processed(" + bereq.http.Accept-Encoding + ", " + req.esi + "," + req.http.X-From-Edge +")";
-      `set beresp.http.x-compress-hint = "on";` // so h2o compresses it on the way out
+      set beresp.http.x-compress-hint = "on"; // so h2o compresses it on the way out
       set beresp.http.Cache-Control = "max-age=31622400,immutable"; # keep it for a year in the browser;
       set beresp.http.Surrogate-Control = "max-age=31622400,immutable";
       set beresp.cacheable = true;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -459,6 +459,7 @@ sub hlx_type_static {
   # them into the URL
   declare local var.path STRING; # resource path
   declare local var.entry STRING; # bundler entry point
+  declare local var.esi STRING;
 
   # Load important information from edge dicts
   call hlx_github_static_owner;
@@ -473,11 +474,13 @@ sub hlx_type_static {
     # and keep only the non-hashed part, i.e. everything before .hlx_
     set var.path = re.group.1;
     set var.entry = re.group.1;
+    set var.esi = "&esi=true";
   } else {
     set req.http.X-Trace = req.http.X-Trace + "(normal)";
     # TODO: check for URL ending with `/` and look up index file
     set var.path = req.http.X-Orig-URL;
     set var.entry = req.http.X-Orig-URL;
+    set var.esi = "";
   }
 
   set req.http.X-Action-Root = "/api/v1/web/" + table.lookup(secrets, "OPENWHISK_NAMESPACE") + "/default/hlx--static";
@@ -488,6 +491,7 @@ sub hlx_type_static {
     + "&ref=" + req.http.X-Github-Static-Ref
     + "&entry=" + var.entry
     + "&path=" + var.path
+    + var.esi
     # TODO: load magic flag
     + "&plain=true"
     + "&allow=" urlencode(req.http.X-Allow)

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -998,6 +998,10 @@ sub vcl_fetch {
 
   call hlx_fetch_static;
 
+  if (beresp.http.X-ESI) {
+    esi;
+  }
+
   return(deliver);
 }
 

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -539,6 +539,8 @@ sub hlx_fetch_static {
     set var.ext = ".hlx_" + digest.hash_sha1(beresp.http.ETag);
 
     if (re.group.2 == var.ext) {
+      esi;
+      set beresp.http.X-ESI = "processed";
       set beresp.http.Cache-Control = "max-age=31622400,immutable"; # keep it for a year in the browser;
       set beresp.http.Surrogate-Control = "max-age=31622400,immutable";
       set beresp.cacheable = true;
@@ -548,9 +550,6 @@ sub hlx_fetch_static {
       error 404 "Invalid";
       set beresp.http.X-Trace = "etag=" + beresp.http.ETag + "; ext=" + var.ext;
 
-    }
-    if (beresp.http.X-ESI == "enabled") {
-      esi;
     }
     return(deliver);
   }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1192,7 +1192,7 @@ sub vcl_error {
   if (obj.status == 902 && req.http.X-Location) {
     set obj.http.Content-Type = "text/html";
     set obj.status = 302;
-    set obj.location = req.http.X-Location;
+    set obj.http.Location = req.http.X-Location;
     synthetic "Found: <a href='" + req.http.X-Location+ "'>" + req.http.X-Location + "</a>";
     return(deliver);
   }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -549,6 +549,9 @@ sub hlx_fetch_static {
       set beresp.http.X-Trace = "etag=" + beresp.http.ETag + "; ext=" + var.ext;
 
     }
+    if (beresp.http.X-ESI == "enabled") {
+      esi;
+    }
     return(deliver);
   }
   if (beresp.http.X-Static == "Raw/Static") {

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -499,7 +499,7 @@ sub hlx_fetch_static {
   # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441
   if (req.http.X-Orig-URL ~ "^(.*)(.hlx_([0-9a-f]){20,40}$)") {
     # tell the browser to keep them forever
-    set beresp.http.Cache-Control = "max-age=31622400"; # keep it for a year in the browser;
+    set beresp.http.Cache-Control = "max-age=31622400,immutable"; # keep it for a year in the browser;
     set beresp.http.Surrogate-Control = "max-age=3600"; # but only for an hour in the shared cache
                                                         # to limit cache poisioning
     set beresp.cacheable = true;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1041,13 +1041,12 @@ sub hlx_bereq {
     }
   }
 
-  # set backend authentication
+  
   if (req.backend == F_AdobeRuntime) {
+    # set backend authentication
     set bereq.http.Authorization = table.lookup(secrets, "OPENWHISK_AUTH");
-  }
 
-  # making sure to get an uncompressed object for ESI
-  if ( req.url.ext == "html" || req.url.ext == "js" || req.url.ext == "css" ) {
+    # making sure to get an uncompressed object for ESI
     unset bereq.http.Accept-Encoding;
   }
 


### PR DESCRIPTION
provide two new resource types for static resources: .esi to replace a static URL with a cacheable static URL and .hlx_[0-9a-f]+ for resources that are cached forever in the browser

In order to increase the cache efficiency of static resources, we are implementing a multi-stage process which replaces the generic, short and uncacheable URLs of static resources like `/scripts/site.js` with long and version-specific URLs like `/scripts/site.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441`. This is done by offering a virtual resource like `/scripts/site.js.esi` that can be included in an ESI tag like `<script src="<esi:include src="/scripts/site.js.esi" />">` from within HTML, JS or CSS (the replacement of `.js` and `.css` file endings iwth `.js.esi` and `.css.esi` will be handled in helix-pipeline and helix-static at a later point in time). This virtual resource will then simply replace the short URL `/scripts/site.js` with the long-cachable URL `/scripts/site.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441` through the ESI resolution process. Any static resource requested with a long-cachable URL will be delivered with Cache-Control headers setting expiry 366 days into the future.

Partial implementation of https://github.com/adobe/helix-pipeline/issues/224#issuecomment-476690621
Requires https://github.com/adobe/helix-cli/pull/797 and https://github.com/adobe/helix-pipeline/pull/281