### PR TITLE
Proxy Strain Subdirectory Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@adobe/helix-shared": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-1.0.2.tgz",
-      "integrity": "sha512-E3V+4FgCPR5mYW72eyKkAe/85gv3XYn56GhpOKJfdU7aZyoo3NJ93yZZta67gifoEs7uNIy5d5LIZMmBqQUKxA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-1.1.0.tgz",
+      "integrity": "sha512-AQPaBQrk+AhJts7a9s9XFkdOxNo5JbswR225bH9y3UkHhKUpQZ+InNdk6Q0TbGDmba4uLTjy7k8Fuepi1z1VYA==",
       "requires": {
         "ajv": "6.10.0",
         "fs-extra": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@adobe/fastly-native-promises": "1.9.1",
-    "@adobe/helix-shared": "1.0.2",
+    "@adobe/helix-shared": "1.1.0",
     "fs-extra": "7.0.1",
     "glob-to-regexp": "0.4.1",
     "uri-js": "4.2.2"

--- a/src/fastly/backends.js
+++ b/src/fastly/backends.js
@@ -57,8 +57,11 @@ async function updatestrains(fastly, version, strains) {
   // filter out all proxy strains
   const proxystrains = strains.getProxyStrains();
   // create a new backend or update and existing one for each origin defined
-  const origins = proxystrains.map(proxystrain => proxystrain.origin);
-  const updateorigins = origins.map(origin => fastly.writeBackend(
+  const origins = {};
+  proxystrains.forEach((proxystrain) => {
+    origins[proxystrain.origin.name] = proxystrain.origin;
+  });
+  const updateorigins = Object.values(origins).map(origin => fastly.writeBackend(
     version,
     origin.name,
     origin.toJSON(),
@@ -66,7 +69,7 @@ async function updatestrains(fastly, version, strains) {
 
   return Promise.all([
     ...updateorigins,
-    writevcl(fastly, version, reset([...Object.values(backends), ...origins]), 'reset.vcl')]);
+    writevcl(fastly, version, reset([...Object.values(backends), ...Object.values(origins)]), 'reset.vcl')]);
 }
 
 module.exports = {

--- a/src/fastly/backends.js
+++ b/src/fastly/backends.js
@@ -64,7 +64,7 @@ async function updatestrains(fastly, version, strains) {
   const updateorigins = Object.values(origins).map(origin => fastly.writeBackend(
     version,
     origin.name,
-    origin.toJSON(),
+    origin.toFastlyJSON(),
   ));
 
   return Promise.all([

--- a/src/fastly/vcl-utils.js
+++ b/src/fastly/vcl-utils.js
@@ -166,7 +166,13 @@ function shielding({ name }) {
 function reset(backends) {
   let retval = '# This file resets shielding for all known backends\n';
 
-  const backendresets = Object.values(backends).map(shielding);
+  const origins = {};
+  Object.values(backends).forEach(backend => {
+    origins[backend.name] = backend;
+  });
+
+
+  const backendresets = Object.values(origins).map(shielding);
 
   retval += backendresets.join('\n');
 

--- a/src/fastly/vcl-utils.js
+++ b/src/fastly/vcl-utils.js
@@ -167,7 +167,7 @@ function reset(backends) {
   let retval = '# This file resets shielding for all known backends\n';
 
   const origins = {};
-  Object.values(backends).forEach(backend => {
+  Object.values(backends).forEach((backend) => {
     origins[backend.name] = backend;
   });
 

--- a/src/fastly/vcl-utils.js
+++ b/src/fastly/vcl-utils.js
@@ -65,11 +65,28 @@ function proxy([strain, vcl]) {
 # Enable passing through of requests
 
 set req.http.X-Proxy = "${strain.origin.useSSL ? 'https' : 'http'}://${strain.origin.address}:${strain.origin.port}/";
+set req.http.X-Proxy-Root = "${strain.origin.path}";
 set req.http.X-Request-Type = "Proxy";
 
 set req.backend = F_${strain.origin.name};
 set req.http.host = "${strain.origin.hostname}";
 `);
+    return [strain, Object.assign(vcl, { body })];
+  }
+  return [strain, vcl];
+}
+
+function proxyurls([strain, vcl]) {
+  const uri = URI.parse(strain.url ? strain.url : '/');
+  const oldpath = uri.path ? uri.path : '/';
+
+  const newpath = (strain.origin && strain.origin.path) ? strain.origin.path : '/';
+
+  if (oldpath !== '/' || newpath !== '/') {
+    const body = vclbody(vcl.body);
+
+    body.push(`# Rewrite the URL to include the proxy path
+set req.url = regsub(req.url, "^${oldpath}", "${newpath}");`);
     return [strain, Object.assign(vcl, { body })];
   }
   return [strain, vcl];
@@ -108,6 +125,7 @@ function resolve(mystrains) {
     .map(strain => [strain, { body: vclbody() }])
     .map(conditions)
     .map(proxy)
+    .map(proxyurls)
     .map(stickybody)
     .map(namebody)
     .filter(([strain, vcl]) => strain.condition || vcl.condition)

--- a/test/backends.test.js
+++ b/test/backends.test.js
@@ -40,7 +40,7 @@ describe('Testing backends.js', () => {
       .init();
 
     assert.ok(await updatestrains(fastly, 1, config.strains));
-    assert.ok(fastly.writeBackend.calledTwice);
+    assert.ok(fastly.writeBackend.calledThrice);
 
     assert.ok(fastly.writeVCL.calledOnce);
 

--- a/test/backends.test.js
+++ b/test/backends.test.js
@@ -47,4 +47,22 @@ describe('Testing backends.js', () => {
     assert.ok(fastly.writeBackend.calledWith(1, 'Proxywwwadobeio3a0a'));
     assert.ok(fastly.writeBackend.calledWith(1, 'publish'));
   });
+
+  it('#updatestrains/demo', async () => {
+    const fastly = {
+      writeBackend: sinon.fake(),
+      writeVCL: sinon.fake(),
+    };
+
+    const config = await new HelixConfig()
+      .withConfigPath(path.resolve(__dirname, 'fixtures/demo.yaml'))
+      .init();
+
+    assert.ok(await updatestrains(fastly, 1, config.strains));
+    assert.ok(fastly.writeBackend.calledOnce);
+
+    assert.ok(fastly.writeVCL.calledOnce);
+
+    assert.ok(fastly.writeBackend.calledWith(1, 'Proxywwwadobeio3a0a'));
+  });
 });

--- a/test/backends.test.js
+++ b/test/backends.test.js
@@ -40,11 +40,11 @@ describe('Testing backends.js', () => {
       .init();
 
     assert.ok(await updatestrains(fastly, 1, config.strains));
-    assert.ok(fastly.writeBackend.calledThrice);
+    assert.ok(fastly.writeBackend.calledTwice);
 
     assert.ok(fastly.writeVCL.calledOnce);
 
-    assert.ok(fastly.writeBackend.calledWith(1, 'Proxywwwadobeio861b'));
+    assert.ok(fastly.writeBackend.calledWith(1, 'Proxywwwadobeio3a0a'));
     assert.ok(fastly.writeBackend.calledWith(1, 'publish'));
   });
 });

--- a/test/fixtures/demo-reset.vcl
+++ b/test/fixtures/demo-reset.vcl
@@ -23,11 +23,3 @@ if (req.backend == F_Proxywwwadobeio3a0a && req.restarts == 0) {
     set req.backend = F_Proxywwwadobeio3a0a;
   }
 }
-if (req.backend == F_publish && req.restarts == 0) {
-  if (server.identity !~ "-IAD$" && req.http.Fastly-FF !~ "-IAD") {
-    set req.backend = ssl_shield_iad_va_us;
-  }
-  if (!req.backend.healthy) {
-    set req.backend = F_publish;
-  }
-}

--- a/test/fixtures/demo.yaml
+++ b/test/fixtures/demo.yaml
@@ -1,0 +1,15 @@
+strains:
+  - name: proxy
+    url: https://proxy.primordialsoup.life
+    origin: https://www.adobe.io/
+  - name: default
+    content: https://github.com/trieloff/helix-demo.git#master
+    static: https://github.com/trieloff/helix-demo.git/htdocs#master
+    code: ssh://git@github.com/trieloff/helix-demo.git#master
+    package: trieloff/adeb2be318b4997c8254862e8815d8c62fe4de49
+  - name: legacy
+    url: https://www.primordialsoup.life/content
+    origin: https://www.adobe.io/content
+  - name: apis
+    url: https://www.primordialsoup.life/products
+    origin: https://www.adobe.io/apis

--- a/test/fixtures/full-reset.vcl
+++ b/test/fixtures/full-reset.vcl
@@ -15,12 +15,12 @@ if (req.backend == F_AdobeRuntime && req.restarts == 0) {
     set req.backend = F_AdobeRuntime;
   }
 }
-if (req.backend == F_Proxywwwadobeio861b && req.restarts == 0) {
+if (req.backend == F_Proxywwwadobeio3a0a && req.restarts == 0) {
   if (server.identity !~ "-IAD$" && req.http.Fastly-FF !~ "-IAD") {
     set req.backend = ssl_shield_iad_va_us;
   }
   if (!req.backend.healthy) {
-    set req.backend = F_Proxywwwadobeio861b;
+    set req.backend = F_Proxywwwadobeio3a0a;
   }
 }
 if (req.backend == F_publish && req.restarts == 0) {
@@ -31,11 +31,11 @@ if (req.backend == F_publish && req.restarts == 0) {
     set req.backend = F_publish;
   }
 }
-if (req.backend == F_Proxywwwadobeio6fab && req.restarts == 0) {
+if (req.backend == F_Proxywwwadobeio3a0a && req.restarts == 0) {
   if (server.identity !~ "-IAD$" && req.http.Fastly-FF !~ "-IAD") {
     set req.backend = ssl_shield_iad_va_us;
   }
   if (!req.backend.healthy) {
-    set req.backend = F_Proxywwwadobeio6fab;
+    set req.backend = F_Proxywwwadobeio3a0a;
   }
 }

--- a/test/fixtures/full-reset.vcl
+++ b/test/fixtures/full-reset.vcl
@@ -31,3 +31,11 @@ if (req.backend == F_publish && req.restarts == 0) {
     set req.backend = F_publish;
   }
 }
+if (req.backend == F_Proxywwwadobeio6fab && req.restarts == 0) {
+  if (server.identity !~ "-IAD$" && req.http.Fastly-FF !~ "-IAD") {
+    set req.backend = ssl_shield_iad_va_us;
+  }
+  if (!req.backend.healthy) {
+    set req.backend = F_Proxywwwadobeio6fab;
+  }
+}

--- a/test/fixtures/full-resolve.vcl
+++ b/test/fixtures/full-resolve.vcl
@@ -14,7 +14,7 @@ if (req.http.Host == "client.project-helix.io") {
   set req.http.X-Proxy-Root = "/";
   set req.http.X-Request-Type = "Proxy";
   
-  set req.backend = F_Proxywwwadobeio861b;
+  set req.backend = F_Proxywwwadobeio3a0a;
   set req.http.host = "www.adobe.io";
   
   set req.http.X-Sticky = "true";
@@ -42,7 +42,7 @@ if (req.http.Host == "client.project-helix.io") {
   set req.http.X-Proxy-Root = "/newdir";
   set req.http.X-Request-Type = "Proxy";
   
-  set req.backend = F_Proxywwwadobeio6fab;
+  set req.backend = F_Proxywwwadobeio3a0a;
   set req.http.host = "www.adobe.io";
   
   # Rewrite the URL to include the proxy path

--- a/test/fixtures/full-resolve.vcl
+++ b/test/fixtures/full-resolve.vcl
@@ -11,6 +11,7 @@ if (req.http.Host == "client.project-helix.io") {
   # Enable passing through of requests
   
   set req.http.X-Proxy = "https://www.adobe.io:443/";
+  set req.http.X-Proxy-Root = "/";
   set req.http.X-Request-Type = "Proxy";
   
   set req.backend = F_Proxywwwadobeio861b;
@@ -23,6 +24,7 @@ if (req.http.Host == "client.project-helix.io") {
   # Enable passing through of requests
   
   set req.http.X-Proxy = "http://192.168.0.1:80/";
+  set req.http.X-Proxy-Root = "/";
   set req.http.X-Request-Type = "Proxy";
   
   set req.backend = F_publish;
@@ -30,6 +32,23 @@ if (req.http.Host == "client.project-helix.io") {
   
   set req.http.X-Sticky = "true";
   set req.http.X-Strain = "proxy-detailed";
+} else if (req.http.Host == "developer.adobe.com" && (req.http.X-FullDirname ~ "^/olddir$" || req.http.X-FullDirname ~ "^/olddir/")) {
+  set req.http.X-Dirname = regsub(req.http.X-FullDirname, "^/olddir", "");
+  set req.http.X-Root-Path = "/olddir";
+  
+  # Enable passing through of requests
+  
+  set req.http.X-Proxy = "https://www.adobe.io:443/";
+  set req.http.X-Proxy-Root = "/newdir";
+  set req.http.X-Request-Type = "Proxy";
+  
+  set req.backend = F_Proxywwwadobeio6fab;
+  set req.http.host = "www.adobe.io";
+  
+  # Rewrite the URL to include the proxy path
+  set req.url = regsub(req.url, "^/olddir", "/newdir");
+  set req.http.X-Sticky = "false";
+  set req.http.X-Strain = "proxy-path";
 } else {
   set req.http.X-Strain = "default";
 }

--- a/test/fixtures/full.yaml
+++ b/test/fixtures/full.yaml
@@ -72,3 +72,7 @@ strains:
       address: 192.168.0.1
       name: publish
       use_ssl: false
+
+  proxy-path:
+    origin: https://www.adobe.io/newdir
+    url: https://developer.adobe.com/olddir

--- a/test/fixtures/urls-resolve.vcl
+++ b/test/fixtures/urls-resolve.vcl
@@ -22,7 +22,7 @@ if (req.http.Host == "www.project-helix.io" && (req.http.X-FullDirname ~ "^/clie
   set req.http.X-Proxy-Root = "/";
   set req.http.X-Request-Type = "Proxy";
   
-  set req.backend = F_Proxywwwadobeio861b;
+  set req.backend = F_Proxywwwadobeio3a0a;
   set req.http.host = "www.adobe.io";
   
   set req.http.X-Sticky = "true";

--- a/test/fixtures/urls-resolve.vcl
+++ b/test/fixtures/urls-resolve.vcl
@@ -3,11 +3,15 @@ set req.http.X-Root-Path = "";
 if (req.http.Host == "www.project-helix.io" && (req.http.X-FullDirname ~ "^/client$" || req.http.X-FullDirname ~ "^/client/")) {
   set req.http.X-Dirname = regsub(req.http.X-FullDirname, "^/client", "");
   set req.http.X-Root-Path = "/client";
+  # Rewrite the URL to include the proxy path
+  set req.url = regsub(req.url, "^/client", "/");
   set req.http.X-Sticky = "false";
   set req.http.X-Strain = "client";
 } else if (req.http.Host == "www.project-helix.io" && (req.http.X-FullDirname ~ "^/pipeline$" || req.http.X-FullDirname ~ "^/pipeline/")) {
   set req.http.X-Dirname = regsub(req.http.X-FullDirname, "^/pipeline", "");
   set req.http.X-Root-Path = "/pipeline";
+  # Rewrite the URL to include the proxy path
+  set req.url = regsub(req.url, "^/pipeline", "/");
   set req.http.X-Sticky = "false";
   set req.http.X-Strain = "pipeline";
 } else if (req.http.Host == "proxy.project-helix.io") {
@@ -15,6 +19,7 @@ if (req.http.Host == "www.project-helix.io" && (req.http.X-FullDirname ~ "^/clie
   # Enable passing through of requests
   
   set req.http.X-Proxy = "https://www.adobe.io:443/";
+  set req.http.X-Proxy-Root = "/";
   set req.http.X-Request-Type = "Proxy";
   
   set req.backend = F_Proxywwwadobeio861b;

--- a/test/vcl-utils.test.js
+++ b/test/vcl-utils.test.js
@@ -76,6 +76,7 @@ describe('Testing vcl-utils.js', () => {
   it('#resolve/noconditions', resolvetest('noconditions'));
   it('#resolve/urls', resolvetest('urls'));
   it('#reset/full', resettest('full'));
+  it('#reset/demo', resettest('demo'));
   it('#parameters/full', parameterstest('full'));
   it('#parameters/noparams', parameterstest('noparams'));
   it('#parameters/manyparams', parameterstest('manyparams'));


### PR DESCRIPTION
Fixes #64 by rewriting `https://helixdomain.com/newpath` to `https://backenddomain.com/oldpath` using the `strain[].origin.path` property and the `strain.url.path` property.

Note: this is a breaking change that changes the behavior of all proxy strains. If you had a proxy strain for `https://helixdomain.com/foobar/` then requests to `https://helixdomain.com/foobar/index.html` would go go `https://backenddomain.com/foobar/index.html`, now they go to `https://backenddomain.com/index.html`. To restore the old behavior, add a `path` to each `origin` in a proxy strain.