### PR TITLE
feat(dispatch): use released dispatch version instead of latest

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -750,7 +750,7 @@ sub hlx_type_dispatch {
 
   set req.http.X-Backend-URL = "/api/v1/web"
     + "/" + var.namespace // i.e. /trieloff
-    + "/helix-services/experimental-dispatch@" + req.http.X-Dispatch-Version
+    + "/helix-services/dispatch@" + req.http.X-Dispatch-Version
     // fallback repo
     + "?static.owner=" + req.http.X-Github-Static-Owner
     + "&static.repo=" + req.http.X-Github-Static-Repo

--- a/src/publish.js
+++ b/src/publish.js
@@ -17,7 +17,7 @@ const vcl = require('./fastly/vcl');
 const dictionaries = require('./fastly/dictionaries');
 const redirects = require('./fastly/redirects');
 
-async function publish(configuration, service, token, version, vclOverrides = {}, dispatchVersion = 'latest', log = console) {
+async function publish(configuration, service, token, version, vclOverrides = {}, dispatchVersion = 'v2', log = console) {
   if (!(!!token && !!service)) {
     log.error('No token or service.');
     return {


### PR DESCRIPTION
with https://github.com/adobe/helix-dispatch/releases/tag/v2.0.0 the URL of the dispatch action has dropped the experimental. This change uses the new version, while also pinning the version to `v2` as discussed here: https://github.com/adobe/helix-publish/issues/128#issuecomment-513220213

fixes #128 – partial revert of #129