### PR TITLE
feat(helix.vcl): avoid leaking of debug headers

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1211,6 +1211,11 @@ sub vcl_deliver {
     set resp.http.Set-Cookie = "X-Strain=" + req.http.X-Strain + "; Secure; HttpOnly; SameSite=Strict;";
   }
 
+  # remove temporary headers used to reconstruct trace information
+  unset resp.http.X-PreFetch-Miss;
+  unset resp.http.X-PreFetch-Pass;
+  unset resp.http.X-PostFetch;
+
   if (!req.http.X-Debug) {
     # Unless we are debugging, shut up chatty headers
     unset resp.http.Access-Control-Allow-Headers;
@@ -1243,9 +1248,6 @@ sub vcl_deliver {
     unset resp.http.X-Timer;
     unset resp.http.X-Trace;
     unset resp.http.X-URL;
-    unset resp.http.X-PreFetch-Miss;
-    unset resp.http.X-PreFetch-Pass;
-    unset resp.http.X-PostFetch;
     unset resp.http.x-xss-protection;
   } else {
     set resp.http.X-Trace = req.http.X-Trace;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1184,17 +1184,14 @@ sub vcl_deliver {
   } else {
     if (resp.http.X-PreFetch-Pass) {
       set req.http.X-Trace = req.http.X-Trace resp.http.X-PreFetch-Pass;
-      unset resp.http.X-PreFetch-Pass;
     }
 
     if (resp.http.X-PreFetch-Miss) {
       set req.http.X-Trace = req.http.X-Trace resp.http.X-PreFetch-Miss;
-      unset resp.http.X-PreFetch-Miss;
     }
 
     if (resp.http.X-PostFetch) {
       set req.http.X-Trace = req.http.X-Trace resp.http.X-PostFetch;
-      unset resp.http.X-PostFetch;
     }
   }
 
@@ -1246,6 +1243,9 @@ sub vcl_deliver {
     unset resp.http.X-Timer;
     unset resp.http.X-Trace;
     unset resp.http.X-URL;
+    unset resp.http.X-PreFetch-Miss;
+    unset resp.http.X-PreFetch-Pass;
+    unset resp.http.X-PostFetch;
     unset resp.http.x-xss-protection;
   } else {
     set resp.http.X-Trace = req.http.X-Trace;


### PR DESCRIPTION
I noticed that some published sites leak the following debug headers:

```
X-PreFetch-Miss
X-PreFetch-Pass
X-PostFetch
```

These temporary headers are used to transport trace information to shield nodes and back and to finally reconstruct the full vcl trace information in `vcl_deliver`. 

This PR makes sure they are unconditionally removed in `vcl_deliver`.