### PR TITLE
feat(dispatch): update to dispatch@v3 with dynamic defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Send a POST request with following (`Content-Type: application/json`-encoded) bo
 * `token`: a Fastly authentication token that has `global` permission on the service config
 * `version`: the version number of a checked-out (editable) version of the above service config
 * `vcl`: an object containing the name of the vcl file (key) to override and its content. For now, only `extensions.vcl` override is supported
-* `dispatchVersion`: the version of the dispatch action to use. Defaults to `latest`.
+* `dispatchVersion`: the version of the dispatch action to use. Defaults to `v3`.
 
 ## Developing Helix Publish
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -17,7 +17,7 @@ const vcl = require('./fastly/vcl');
 const dictionaries = require('./fastly/dictionaries');
 const redirects = require('./fastly/redirects');
 
-async function publish(configuration, service, token, version, vclOverrides = {}, dispatchVersion = 'v2', log = console) {
+async function publish(configuration, service, token, version, vclOverrides = {}, dispatchVersion = 'v3', log = console) {
   if (!(!!token && !!service)) {
     log.error('No token or service.');
     return {


### PR DESCRIPTION
BREAKING CHANGE: This changes the default dispatch version from v2 to v3. v3 introduces dynamic defaults (fallback to `default.htnl` in the same folder if file can't be found), which is a breaking change

enables dynamic defaults, see https://github.com/adobe/helix-dispatch/issues/138

**Note:** as this is a breaking change, it will require a new helix-cli version, too.