### PR TITLE
Algolia proxy

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -557,6 +557,10 @@ sub hlx_type_query {
   # get it from Algolia
   set req.backend = F_Algolia;
 
+  # Load important information for content repo from edge dicts
+  call hlx_owner;
+  call hlx_repo;
+
   # run map queries
   include "queries.vcl";
 }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1206,7 +1206,7 @@ sub hlx_bereq {
       set bereq.http.Host = "raw.githubusercontent.com";
     } elseif (req.backend == F_AzureBlobs) {
       set bereq.http.Host = "hlx.blob.core.windows.net";
-    } elseiif (req.backend == F_Algolia) {
+    } elseif (req.backend == F_Algolia) {
       # we are passing the APP ID through the secrets table
       set bereq.http.Host = table.lookup(secrets, "ALGOLIA_APP_ID") + "-dsn.algolia.net";
     }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1223,7 +1223,7 @@ sub hlx_bereq {
   } elseif (req.backend == F_Algolia) {
     # set Algolia Backend authentication
     set bereq.http.X-Algolia-Application-Id = table.lookup(secrets, "ALGOLIA_APP_ID");
-    set bereq.http.X-Algolia-API-Key = table.lookup(secrets, "ALGOLIA_API_KEY")
+    set bereq.http.X-Algolia-API-Key = table.lookup(secrets, "ALGOLIA_API_KEY");
   }
 
   # making sure to get an uncompressed object for ESI

--- a/package-lock.json
+++ b/package-lock.json
@@ -16680,9 +16680,9 @@
       "dev": true
     },
     "tree-kill": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
     },
     "trim-newlines": {
       "version": "2.0.0",

--- a/src/fastly/algolia.js
+++ b/src/fastly/algolia.js
@@ -13,12 +13,13 @@ function encode(expression, parameters) {
   if (!expression) {
     return '""';
   }
+  const cleanexpression = expression.replace(/\n/g, '');
   if (!parameters || parameters.length===0) {
-    return `"${encodeURIComponent(expression)}"`;
+    return `"${encodeURIComponent(cleanexpression)}"`;
   }
   return parameters.reduce((expr, param) => {
-    return '"' + expr.replace('%24%7B' + param + '%7D', `" + regsub(querystring.filter_except(req.url, "${param}"), "^.*=", "") + "`);
-  }, encodeURIComponent(expression)) + '"';
+    return '"' + expr.replace('%24%7B' + param + '%7D', `" + regsub(querystring.filter_except(req.url, "${param}"), "^[^=]*=?", "") + "`);
+  }, encodeURIComponent(cleanexpression)) + '"';
 }
 
 function queryvclsnippet(index, query) {
@@ -31,7 +32,7 @@ function queryvclsnippet(index, query) {
    + "?query=" + ${encode(query.query, query.parameters)}
    + "&filters=" + ${encode(query.filters, query.parameters)}
    + "&facets=" + ${encode(query.facets, query.parameters)}
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^[^=]*=?", "")
    + "&hitsPerPage=${query.hitsPerPage}";
 }`;
 }

--- a/src/fastly/algolia.js
+++ b/src/fastly/algolia.js
@@ -19,7 +19,6 @@ function encode(expression, parameters) {
 }
 
 function queryvclsnippet(index, query) {
-  console.log('making vcl for', index, query.name);
   return `if (req.url.path == "/_query/${index}/${query.name}") {
   set req.http.X-Surrogate-Control = "max-age=${query.cache}";
   set req.http.X-Backend-URL = "/1/indexes/"
@@ -28,7 +27,9 @@ function queryvclsnippet(index, query) {
    + "${index}" # from the index name
    + "?query=" + ${encode(query.query, query.parameters)}
    + "&filters=" + ${encode(query.filters, query.parameters)}
-   + "&facets=" + ${encode(query.facets, query.parameters)};
+   + "&facets=" + ${encode(query.facets, query.parameters)}
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")";
+   + "&hitsPerPage=${query.hitsPerPage}";
 }`;
 }
 

--- a/src/fastly/algolia.js
+++ b/src/fastly/algolia.js
@@ -31,7 +31,7 @@ function queryvclsnippet(index, query) {
    + "?query=" + ${encode(query.query, query.parameters)}
    + "&filters=" + ${encode(query.filters, query.parameters)}
    + "&facets=" + ${encode(query.facets, query.parameters)}
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "");
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")
    + "&hitsPerPage=${query.hitsPerPage}";
 }`;
 }

--- a/src/fastly/algolia.js
+++ b/src/fastly/algolia.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+function encode(expression, parameters) {
+  if (!expression) {
+    return '""';
+  }
+  return parameters.reduce((expr, param) => {
+    return '"' + expr.replace('%24%7B' + param + '%7D', `" + regsub(querystring.filter_except(req.url, "${param}"), "^.*=", "") + "`);
+  }, encodeURIComponent(expression)) + '"';
+}
+
+function queryvclsnippet(index, query) {
+  console.log('making vcl for', index, query.name);
+  return `if (req.url.path == "/_query/${index}/${query.name}") {
+  set req.http.X-Surrogate-Control = "max-age=${query.cache}";
+  set req.http.X-Backend-URL = "/1/indexes/"
+   + req.http.X-Owner + "--"
+   + req.http.X-Repo + "--"
+   + "${index}" # from the index name
+   + "?query=" + ${encode(query.query, query.parameters)}
+   + "&filters=" + ${encode(query.filters, query.parameters)}
+   + "&facets=" + ${encode(query.facets, query.parameters)};
+}`;
+}
+
+function queryvcl(indices) {
+  function * snippets() {
+    for (let i = 0;i < indices.length; ++i) {
+      for (let j = 0;j< indices[i].queries.length;++j) {
+        yield queryvclsnippet(indices[i].name, indices[i].queries[j]);
+      }
+    }
+  }
+  return Array.from(snippets()).join('\n');
+}
+
+module.exports = { queryvcl, encode };

--- a/src/fastly/algolia.js
+++ b/src/fastly/algolia.js
@@ -13,6 +13,9 @@ function encode(expression, parameters) {
   if (!expression) {
     return '""';
   }
+  if (!parameters || parameters.length===0) {
+    return `"${encodeURIComponent(expression)}"`;
+  }
   return parameters.reduce((expr, param) => {
     return '"' + expr.replace('%24%7B' + param + '%7D', `" + regsub(querystring.filter_except(req.url, "${param}"), "^.*=", "") + "`);
   }, encodeURIComponent(expression)) + '"';
@@ -28,7 +31,7 @@ function queryvclsnippet(index, query) {
    + "?query=" + ${encode(query.query, query.parameters)}
    + "&filters=" + ${encode(query.filters, query.parameters)}
    + "&facets=" + ${encode(query.facets, query.parameters)}
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")";
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "");
    + "&hitsPerPage=${query.hitsPerPage}";
 }`;
 }

--- a/src/fastly/algolia.js
+++ b/src/fastly/algolia.js
@@ -14,12 +14,10 @@ function encode(expression, parameters) {
     return '""';
   }
   const cleanexpression = expression.replace(/\n/g, '');
-  if (!parameters || parameters.length===0) {
+  if (!parameters || parameters.length === 0) {
     return `"${encodeURIComponent(cleanexpression)}"`;
   }
-  return parameters.reduce((expr, param) => {
-    return '"' + expr.replace('%24%7B' + param + '%7D', `" + regsub(querystring.filter_except(req.url, "${param}"), "^[^=]*=?", "") + "`);
-  }, encodeURIComponent(cleanexpression)) + '"';
+  return `${parameters.reduce((expr, param) => `"${expr.replace(`%24%7B${param}%7D`, `" + regsub(querystring.filter_except(req.url, "${param}"), "^[^=]*=?", "") + "`)}`, encodeURIComponent(cleanexpression))}"`;
 }
 
 function queryvclsnippet(index, query) {
@@ -38,9 +36,9 @@ function queryvclsnippet(index, query) {
 }
 
 function queryvcl(indices) {
-  function * snippets() {
-    for (let i = 0;i < indices.length; ++i) {
-      for (let j = 0;j< indices[i].queries.length;++j) {
+  function* snippets() {
+    for (let i = 0; i < indices.length; i += 1) {
+      for (let j = 0; j < indices[i].queries.length; j += 1) {
         yield queryvclsnippet(indices[i].name, indices[i].queries[j]);
       }
     }

--- a/src/fastly/backends.js
+++ b/src/fastly/backends.js
@@ -59,9 +59,24 @@ const backends = {
     use_ssl: true,
   },
 };
-async function init(fastly, version) {
+async function init(fastly, version, algoliaappid) {
   // go over all defined backends and create a new one
-  return Promise.all(Object.values(backends).map((backend) => fastly.writeBackend(
+  const mybackends = algoliaappid ? [...Object.values(backends), {
+    hostname: `${algoliaappid}-dsn.algolia.net`,
+    error_threshold: 0,
+    first_byte_timeout: 60000,
+    weight: 100,
+    address: `${algoliaappid}-dsn.algolia.net`,
+    connect_timeout: 1000,
+    name: 'Algolia',
+    port: 443,
+    between_bytes_timeout: 10000,
+    shield: 'iad-va-us',
+    ssl_cert_hostname: `${algoliaappid}-dsn.algolia.net`,
+    max_conn: 200,
+    use_ssl: true,
+  }] : Object.values(backends);
+  return Promise.all(mybackends.map((backend) => fastly.writeBackend(
     version,
     backend.name,
     backend,

--- a/src/fastly/vcl.js
+++ b/src/fastly/vcl.js
@@ -62,9 +62,17 @@ function dynamic(fastly, version, dispatchVersion) {
   ]);
 }
 
+function queries(fastly, version, indexconfig) {
+  const content = '';
+  console.log(indexconfig.indices.length);
+
+  return writevcl(fastly, version, content, 'queries.vcl');
+}
+
 module.exports = {
   init,
   updatestrains,
   extensions,
   dynamic,
+  queries,
 };

--- a/src/fastly/vcl.js
+++ b/src/fastly/vcl.js
@@ -21,6 +21,9 @@ const {
   writevcl,
   reqHeader,
 } = require('./vcl-utils');
+
+const { queryvcl } = require('./algolia');
+
 const package = require('../../package.json');
 
 function basedir() {
@@ -63,9 +66,7 @@ function dynamic(fastly, version, dispatchVersion) {
 }
 
 function queries(fastly, version, indexconfig) {
-  const content = '';
-  console.log(indexconfig.indices.length);
-
+  const content = queryvcl(indexconfig.indices || []);
   return writevcl(fastly, version, content, 'queries.vcl');
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ async function publishConfig(params) {
     params.dispatchVersion,
     // eslint-disable-next-line no-underscore-dangle
     params.__ow_logger,
+    params.indexconfig,
+    params.algoliaappid,
   );
 }
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-const { HelixConfig } = require('@adobe/helix-shared');
+const { HelixConfig, IndexConfig } = require('@adobe/helix-shared');
 const initfastly = require('@adobe/fastly-native-promises');
 const backends = require('./fastly/backends');
 const vcl = require('./fastly/vcl');
@@ -18,7 +18,7 @@ const dictionaries = require('./fastly/dictionaries');
 const redirects = require('./fastly/redirects');
 
 /**
- * 
+ *
  * @param {object} configuration the Helix Strains configuration
  * @param {string} service the Fastly Service ID
  * @param {string} token the Fastly Auth token
@@ -26,8 +26,10 @@ const redirects = require('./fastly/redirects');
  * @param {object} vclOverrides the VCL overrides (extension points)
  * @param {string} dispatchVersion the helix-dispatch microservice version to use
  * @param {object} log a logger
+ * @param {object} iconfig the IndexConfig from helix-shared
+ * @param {string} algoliaappid Algolia App ID (not secret)
  */
-async function publish(configuration, service, token, version, vclOverrides = {}, dispatchVersion = 'v3', log = console) {
+async function publish(configuration, service, token, version, vclOverrides = {}, dispatchVersion = 'v3', log = console, iconfig, algoliaappid) {
   if (!(!!token && !!service)) {
     log.error('No token or service.');
     return {
@@ -43,15 +45,22 @@ async function publish(configuration, service, token, version, vclOverrides = {}
       .withLogger(log)
       .withJSON(configuration)
       .init();
+
+    const indexconfig = await new IndexConfig()
+      .withLogger(log)
+      .withJSON(iconfig)
+      .init();
+
     const fastly = await initfastly(token, service);
     log.info('running publishing tasks...');
     return Promise.all([
-      backends.init(fastly, version),
+      backends.init(fastly, version, algoliaappid),
       backends.updatestrains(fastly, version, config.strains),
       vcl.init(fastly, version),
       vcl.dynamic(fastly, version, dispatchVersion),
       vcl.extensions(fastly, version, vclOverrides),
       vcl.updatestrains(fastly, version, config.strains),
+      vcl.queries(fastly, version, indexconfig),
       redirects.updatestrains(fastly, version, config.strains),
       dictionaries.init(
         fastly,

--- a/src/publish.js
+++ b/src/publish.js
@@ -17,6 +17,16 @@ const vcl = require('./fastly/vcl');
 const dictionaries = require('./fastly/dictionaries');
 const redirects = require('./fastly/redirects');
 
+/**
+ * 
+ * @param {object} configuration the Helix Strains configuration
+ * @param {string} service the Fastly Service ID
+ * @param {string} token the Fastly Auth token
+ * @param {string} version the Helix CLI version
+ * @param {object} vclOverrides the VCL overrides (extension points)
+ * @param {string} dispatchVersion the helix-dispatch microservice version to use
+ * @param {object} log a logger
+ */
 async function publish(configuration, service, token, version, vclOverrides = {}, dispatchVersion = 'v3', log = console) {
   if (!(!!token && !!service)) {
     log.error('No token or service.');

--- a/test/algolia.test.js
+++ b/test/algolia.test.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const assert = require('assert');
+const fs = require('fs-extra');
+const path = require('path');
+const { IndexConfig } = require('@adobe/helix-shared');
+const { queryvcl, encode } = require('../src/fastly/algolia');
+
+/* eslint-env mocha */
+
+describe('Test Query VCL generation', () => {
+  it('Generates empty VCL for empty config', async () => {
+    const indexconfig = await new IndexConfig()
+      .withConfigPath(path.resolve(__dirname, 'fixtures/no-queries.yaml'))
+      .init();
+
+    assert.equal(queryvcl(indexconfig.indices), '');
+  });
+
+  it('Generates valid VCL for valid config', async () => {
+    const indexconfig = await new IndexConfig()
+      .withConfigPath(path.resolve(__dirname, 'fixtures/example-queries.yaml'))
+      .init();
+
+    const vcl = fs.readFileSync(path.resolve(__dirname, 'fixtures/example-queries.vcl')).toString();
+
+    assert.equal(queryvcl(indexconfig.indices), vcl);
+  });
+});
+
+describe('Test expression parser', () => {
+  it('Parses expressions', () => {
+    assert.equal(encode('author:${author}', ['author']), `"author%3A" + regsub(querystring.filter_except(req.url, "author"), "^.*=", "") + ""`);
+    assert.equal(encode('author:${foobar}', ['foobar']), `"author%3A" + regsub(querystring.filter_except(req.url, "foobar"), "^.*=", "") + ""`);
+    assert.equal(encode('author:${foobar}', ['author']), `"author%3A%24%7Bfoobar%7D"`);
+  });
+});

--- a/test/algolia.test.js
+++ b/test/algolia.test.js
@@ -16,6 +16,7 @@ const { IndexConfig } = require('@adobe/helix-shared');
 const { queryvcl, encode } = require('../src/fastly/algolia');
 
 /* eslint-env mocha */
+/* eslint-disable no-template-curly-in-string */
 
 describe('Test Query VCL generation', () => {
   it('Generates empty VCL for empty config', async () => {
@@ -39,8 +40,8 @@ describe('Test Query VCL generation', () => {
 
 describe('Test expression parser', () => {
   it('Parses expressions', () => {
-    assert.equal(encode('author:${author}', ['author']), `"author%3A" + regsub(querystring.filter_except(req.url, "author"), "^[^=]*=?", "") + ""`);
-    assert.equal(encode('author:${foobar}', ['foobar']), `"author%3A" + regsub(querystring.filter_except(req.url, "foobar"), "^[^=]*=?", "") + ""`);
-    assert.equal(encode('author:${foobar}', ['author']), `"author%3A%24%7Bfoobar%7D"`);
+    assert.equal(encode('author:${author}', ['author']), '"author%3A" + regsub(querystring.filter_except(req.url, "author"), "^[^=]*=?", "") + ""');
+    assert.equal(encode('author:${foobar}', ['foobar']), '"author%3A" + regsub(querystring.filter_except(req.url, "foobar"), "^[^=]*=?", "") + ""');
+    assert.equal(encode('author:${foobar}', ['author']), '"author%3A%24%7Bfoobar%7D"');
   });
 });

--- a/test/algolia.test.js
+++ b/test/algolia.test.js
@@ -39,8 +39,8 @@ describe('Test Query VCL generation', () => {
 
 describe('Test expression parser', () => {
   it('Parses expressions', () => {
-    assert.equal(encode('author:${author}', ['author']), `"author%3A" + regsub(querystring.filter_except(req.url, "author"), "^.*=", "") + ""`);
-    assert.equal(encode('author:${foobar}', ['foobar']), `"author%3A" + regsub(querystring.filter_except(req.url, "foobar"), "^.*=", "") + ""`);
+    assert.equal(encode('author:${author}', ['author']), `"author%3A" + regsub(querystring.filter_except(req.url, "author"), "^[^=]*=?", "") + ""`);
+    assert.equal(encode('author:${foobar}', ['foobar']), `"author%3A" + regsub(querystring.filter_except(req.url, "foobar"), "^[^=]*=?", "") + ""`);
     assert.equal(encode('author:${foobar}', ['author']), `"author%3A%24%7Bfoobar%7D"`);
   });
 });

--- a/test/fixtures/example-queries.vcl
+++ b/test/fixtures/example-queries.vcl
@@ -1,10 +1,36 @@
+if (req.url.path == "/_query/blog-posts/fresh") {
+  set req.http.X-Surrogate-Control = "max-age=0";
+  set req.http.X-Backend-URL = "/1/indexes/"
+   + req.http.X-Owner + "--"
+   + req.http.X-Repo + "--"
+   + "blog-posts" # from the index name
+   + "?query=" + *"
+   + "&filters=" + ""
+   + "&facets=" + ""
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")";
+   + "&hitsPerPage=25";
+}
+if (req.url.path == "/_query/blog-posts/all") {
+  set req.http.X-Surrogate-Control = "max-age=600";
+  set req.http.X-Backend-URL = "/1/indexes/"
+   + req.http.X-Owner + "--"
+   + req.http.X-Repo + "--"
+   + "blog-posts" # from the index name
+   + "?query=" + *"
+   + "&filters=" + ""
+   + "&facets=" + ""
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")";
+   + "&hitsPerPage=25";
+}
 if (req.url.path == "/_query/blog-posts/by-author") {
   set req.http.X-Surrogate-Control = "max-age=300";
   set req.http.X-Backend-URL = "/1/indexes/"
    + req.http.X-Owner + "--"
    + req.http.X-Repo + "--"
    + "blog-posts" # from the index name
-   + "?query=*"
-   + "&filters="
-   + "&facets=";
+   + "?query=" + "*"
+   + "&filters=" + "author%3A" + regsub(querystring.filter_except(req.url, "author"), "^.*=", "") + "%0A"
+   + "&facets=" + ""
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")";
+   + "&hitsPerPage=25";
 }

--- a/test/fixtures/example-queries.vcl
+++ b/test/fixtures/example-queries.vcl
@@ -4,10 +4,10 @@ if (req.url.path == "/_query/blog-posts/fresh") {
    + req.http.X-Owner + "--"
    + req.http.X-Repo + "--"
    + "blog-posts" # from the index name
-   + "?query=" + *"
+   + "?query=" + "*"
    + "&filters=" + ""
    + "&facets=" + ""
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")";
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "");
    + "&hitsPerPage=25";
 }
 if (req.url.path == "/_query/blog-posts/all") {
@@ -16,10 +16,10 @@ if (req.url.path == "/_query/blog-posts/all") {
    + req.http.X-Owner + "--"
    + req.http.X-Repo + "--"
    + "blog-posts" # from the index name
-   + "?query=" + *"
+   + "?query=" + "*"
    + "&filters=" + ""
    + "&facets=" + ""
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")";
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "");
    + "&hitsPerPage=25";
 }
 if (req.url.path == "/_query/blog-posts/by-author") {
@@ -31,6 +31,6 @@ if (req.url.path == "/_query/blog-posts/by-author") {
    + "?query=" + "*"
    + "&filters=" + "author%3A" + regsub(querystring.filter_except(req.url, "author"), "^.*=", "") + "%0A"
    + "&facets=" + ""
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")";
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "");
    + "&hitsPerPage=25";
 }

--- a/test/fixtures/example-queries.vcl
+++ b/test/fixtures/example-queries.vcl
@@ -7,7 +7,7 @@ if (req.url.path == "/_query/blog-posts/fresh") {
    + "?query=" + "*"
    + "&filters=" + ""
    + "&facets=" + ""
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^[^=]*=?", "")
    + "&hitsPerPage=25";
 }
 if (req.url.path == "/_query/blog-posts/all") {
@@ -19,7 +19,7 @@ if (req.url.path == "/_query/blog-posts/all") {
    + "?query=" + "*"
    + "&filters=" + ""
    + "&facets=" + ""
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^[^=]*=?", "")
    + "&hitsPerPage=25";
 }
 if (req.url.path == "/_query/blog-posts/by-author") {
@@ -29,8 +29,8 @@ if (req.url.path == "/_query/blog-posts/by-author") {
    + req.http.X-Repo + "--"
    + "blog-posts" # from the index name
    + "?query=" + "*"
-   + "&filters=" + "author%3A" + regsub(querystring.filter_except(req.url, "author"), "^.*=", "") + "%0A"
+   + "&filters=" + "author%3A" + regsub(querystring.filter_except(req.url, "author"), "^[^=]*=?", "") + ""
    + "&facets=" + ""
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^[^=]*=?", "")
    + "&hitsPerPage=25";
 }

--- a/test/fixtures/example-queries.vcl
+++ b/test/fixtures/example-queries.vcl
@@ -1,0 +1,10 @@
+if (req.url.path == "/_query/blog-posts/by-author") {
+  set req.http.X-Surrogate-Control = "max-age=300";
+  set req.http.X-Backend-URL = "/1/indexes/"
+   + req.http.X-Owner + "--"
+   + req.http.X-Repo + "--"
+   + "blog-posts" # from the index name
+   + "?query=*"
+   + "&filters="
+   + "&facets=";
+}

--- a/test/fixtures/example-queries.vcl
+++ b/test/fixtures/example-queries.vcl
@@ -7,7 +7,7 @@ if (req.url.path == "/_query/blog-posts/fresh") {
    + "?query=" + "*"
    + "&filters=" + ""
    + "&facets=" + ""
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "");
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")
    + "&hitsPerPage=25";
 }
 if (req.url.path == "/_query/blog-posts/all") {
@@ -19,7 +19,7 @@ if (req.url.path == "/_query/blog-posts/all") {
    + "?query=" + "*"
    + "&filters=" + ""
    + "&facets=" + ""
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "");
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")
    + "&hitsPerPage=25";
 }
 if (req.url.path == "/_query/blog-posts/by-author") {
@@ -31,6 +31,6 @@ if (req.url.path == "/_query/blog-posts/by-author") {
    + "?query=" + "*"
    + "&filters=" + "author%3A" + regsub(querystring.filter_except(req.url, "author"), "^.*=", "") + "%0A"
    + "&facets=" + ""
-   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "");
+   + "&page=" + regsub(querystring.filter_except(req.url, "page"), "^.*=", "")
    + "&hitsPerPage=25";
 }

--- a/test/fixtures/example-queries.yaml
+++ b/test/fixtures/example-queries.yaml
@@ -1,0 +1,39 @@
+version: 1
+indices:
+  blog-posts:
+    source: html
+    fetch: https://${repo}-${owner}.project-helix.page/${path}
+    properties:
+      author:
+        select: main > div:nth-of-type(3) > p:nth-of-type(1)
+        value: |
+          ${match('by (.*)')}
+        faceted: true
+      title:
+        select: h1:first-of-type
+        value: |
+          ${textContent()}
+      date:
+        select: main > div:nth-of-type(3) > p:nth-of-type(2)
+        value: |
+          ${parseTimestamp('[POSTED ON] MM-DD-YYYY')}
+      topics:
+        select: main > div:last-of-type > p:first-of-type
+        values: |
+          ${match('(Topics: )? ([^,]+)')}
+        faceted: true
+      hero:
+        select: main > div > img:first-of-type
+        value: |
+          ${attribute('src')}
+    queries:
+      all:
+        query: "*"
+        hitsPerPage: 25
+        cache: 600
+      by-author:
+        parameters: author
+        query: "*"
+        filters: |
+          author:${author}
+        cache: "300"

--- a/test/fixtures/example-queries.yaml
+++ b/test/fixtures/example-queries.yaml
@@ -27,6 +27,9 @@ indices:
         value: |
           ${attribute('src')}
     queries:
+      fresh:
+        query: "*"
+        hitsPerPage: 25
       all:
         query: "*"
         hitsPerPage: 25

--- a/test/fixtures/recordings/Integration-Test_519117731/Test-publish-function-locally_1268185746/recording.har
+++ b/test/fixtures/recordings/Integration-Test_519117731/Test-publish-function-locally_1268185746/recording.har
@@ -4,15 +4,130 @@
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
-      "version": "3.0.0"
+      "version": "4.0.0"
     },
     "entries": [
+      {
+        "_id": "de15925020b3a1b47ff757bd743e62a4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 174,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_owners"
+        },
+        "response": {
+          "bodySize": 214,
+          "content": {
+            "mimeType": "application/json",
+            "size": 214,
+            "text": "{\"id\":\"6tlvGa6erOOoBYRvJT7hS9\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"name\":\"strain_owners\",\"deleted_at\":null,\"updated_at\":\"2019-07-18T05:36:20Z\",\"version\":247,\"created_at\":\"2018-07-19T16:00:41Z\",\"write_only\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "content-length",
+              "value": "214"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4049-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611892.229288,VS0,VE275"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 496,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 496
+        }
+      },
       {
         "_id": "62e9d1e1e2b8f510fe69c68320f96156",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1180,
+          "bodySize": 1300,
           "cookies": [],
           "headers": [
             {
@@ -29,7 +144,7 @@
             },
             {
               "name": "content-length",
-              "value": 1180
+              "value": 1300
             }
           ],
           "headersSize": 206,
@@ -39,11 +154,11 @@
           "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/vcl"
         },
         "response": {
-          "bodySize": 69,
+          "bodySize": 64,
           "content": {
             "mimeType": "application/json",
-            "size": 69,
-            "text": "{\"msg\":\"Duplicate record\",\"detail\":\"Duplicate vcl: 'extensions.vcl'\"}"
+            "size": 64,
+            "text": "{\"msg\":\"Duplicate record\",\"detail\":\"Duplicate vcl: 'reset.vcl'\"}"
           },
           "cookies": [],
           "headers": [
@@ -61,11 +176,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "998"
+              "value": "938"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -77,11 +192,11 @@
             },
             {
               "name": "content-length",
-              "value": "69"
+              "value": "64"
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
             },
             {
               "name": "connection",
@@ -89,7 +204,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4052-HHN"
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4066-HHN"
             },
             {
               "name": "x-cache",
@@ -101,7 +216,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.746678,VS0,VE275"
+              "value": "S1579611892.216826,VS0,VE184"
             },
             {
               "name": "vary",
@@ -118,8 +233,8 @@
           "status": 409,
           "statusText": "Conflict"
         },
-        "startedDateTime": "2020-01-13T17:03:44.567Z",
-        "time": 480,
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 387,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -127,7 +242,122 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 480
+          "wait": 387
+        }
+      },
+      {
+        "_id": "a5138c4ffac0b0acf57feadedcb8ab50",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 179,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_index_files"
+        },
+        "response": {
+          "bodySize": 219,
+          "content": {
+            "mimeType": "application/json",
+            "size": 219,
+            "text": "{\"deleted_at\":null,\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\",\"created_at\":\"2018-08-24T00:06:03Z\",\"write_only\":true,\"id\":\"3ovyFLrfhurRT4VXkjCjaq\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"name\":\"strain_index_files\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "content-length",
+              "value": "219"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4046-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611892.242998,VS0,VE239"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 454,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 454
         }
       },
       {
@@ -171,6 +401,14 @@
           "cookies": [],
           "headers": [
             {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "71"
+            },
+            {
               "name": "status",
               "value": "409 Conflict"
             },
@@ -184,11 +422,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "993"
+              "value": "932"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -199,20 +437,12 @@
               "value": "1.1 varnish, 1.1 varnish"
             },
             {
-              "name": "content-length",
-              "value": "71"
-            },
-            {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4075-HHN"
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4029-HHN"
             },
             {
               "name": "x-cache",
@@ -224,7 +454,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.747726,VS0,VE337"
+              "value": "S1579611892.223102,VS0,VE267"
             },
             {
               "name": "vary",
@@ -241,8 +471,8 @@
           "status": 409,
           "statusText": "Conflict"
         },
-        "startedDateTime": "2020-01-13T17:03:44.567Z",
-        "time": 558,
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 460,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -250,237 +480,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 558
-        }
-      },
-      {
-        "_id": "dcb1844cc38b212cfae957ac8a15b134",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 178,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_root_paths"
-        },
-        "response": {
-          "bodySize": 218,
-          "content": {
-            "mimeType": "application/json",
-            "size": 218,
-            "text": "{\"created_at\":\"2018-07-19T16:00:41Z\",\"version\":247,\"name\":\"strain_root_paths\",\"updated_at\":\"2019-07-18T05:36:20Z\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"id\":\"6tmANh9iLMvWGSoWMt2xIe\",\"deleted_at\":null,\"write_only\":true}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "218"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4077-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.753468,VS0,VE317"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 526,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 526
-        }
-      },
-      {
-        "_id": "dd93f420a54ea746bbd8a41f46e86d15",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 180,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_action_roots"
-        },
-        "response": {
-          "bodySize": 220,
-          "content": {
-            "mimeType": "application/json",
-            "size": 220,
-            "text": "{\"write_only\":true,\"version\":247,\"name\":\"strain_action_roots\",\"created_at\":\"2018-07-19T16:00:41Z\",\"id\":\"6tmAIs0aCfNXF6zsmtNScQ\",\"deleted_at\":null,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"updated_at\":\"2019-07-18T05:36:20Z\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "220"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4059-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.761206,VS0,VE312"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 528,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 528
+          "wait": 460
         }
       },
       {
@@ -515,7 +515,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 226,
-            "text": "{\"deleted_at\":null,\"updated_at\":\"2019-07-18T05:36:20Z\",\"name\":\"strain_github_static_root\",\"write_only\":true,\"id\":\"1C7mznzU9PHL2isc4Qah6L\",\"version\":247,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"created_at\":\"2018-09-09T20:27:25Z\"}"
+            "text": "{\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"write_only\":true,\"created_at\":\"2018-09-09T20:27:25Z\",\"updated_at\":\"2019-07-18T05:36:20Z\",\"version\":247,\"name\":\"strain_github_static_root\",\"id\":\"1C7mznzU9PHL2isc4Qah6L\",\"deleted_at\":null}"
           },
           "cookies": [],
           "headers": [
@@ -549,7 +549,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
             },
             {
               "name": "connection",
@@ -557,7 +557,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4020-HHN"
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4040-HHN"
             },
             {
               "name": "x-cache",
@@ -569,7 +569,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.763717,VS0,VE309"
+              "value": "S1579611892.244747,VS0,VE253"
             },
             {
               "name": "vary",
@@ -586,8 +586,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 530,
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 477,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -595,812 +595,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 530
-        }
-      },
-      {
-        "_id": "357c2023ea8e0569ddd980e23a9b2723",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 168,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/secrets"
-        },
-        "response": {
-          "bodySize": 208,
-          "content": {
-            "mimeType": "application/json",
-            "size": 208,
-            "text": "{\"name\":\"secrets\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"write_only\":true,\"updated_at\":\"2019-07-18T05:36:20Z\",\"deleted_at\":null,\"version\":247,\"id\":\"6tlJbZRVUMSvAV6QLUKKrm\",\"created_at\":\"2018-07-19T16:00:41Z\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "208"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4069-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.757519,VS0,VE317"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 532,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 532
-        }
-      },
-      {
-        "_id": "e37f8a48343cda591f65a968582bb678",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 173,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_repos"
-        },
-        "response": {
-          "bodySize": 213,
-          "content": {
-            "mimeType": "application/json",
-            "size": 213,
-            "text": "{\"name\":\"strain_repos\",\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\",\"write_only\":true,\"deleted_at\":null,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"id\":\"6tmoyiJsES3E5YlwmjF8ls\",\"created_at\":\"2018-07-19T16:00:41Z\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "213"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4042-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.758470,VS0,VE316"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 541,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 541
-        }
-      },
-      {
-        "_id": "40004b211648a5136998f08a36b4837c",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 172,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_deny"
-        },
-        "response": {
-          "bodySize": 212,
-          "content": {
-            "mimeType": "application/json",
-            "size": 212,
-            "text": "{\"id\":\"0Z4tRqFgpgkkMuicA4X32T\",\"deleted_at\":null,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"updated_at\":\"2019-07-18T05:36:20Z\",\"version\":247,\"name\":\"strain_deny\",\"created_at\":\"2018-09-09T20:27:24Z\",\"write_only\":true}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "212"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4079-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.766190,VS0,VE312"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 543,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 543
-        }
-      },
-      {
-        "_id": "de15925020b3a1b47ff757bd743e62a4",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 174,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_owners"
-        },
-        "response": {
-          "bodySize": 214,
-          "content": {
-            "mimeType": "application/json",
-            "size": 214,
-            "text": "{\"write_only\":true,\"id\":\"6tlvGa6erOOoBYRvJT7hS9\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"version\":247,\"deleted_at\":null,\"updated_at\":\"2019-07-18T05:36:20Z\",\"name\":\"strain_owners\",\"created_at\":\"2018-07-19T16:00:41Z\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "214"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4032-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.755371,VS0,VE309"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 518,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 518
-        }
-      },
-      {
-        "_id": "a5138c4ffac0b0acf57feadedcb8ab50",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 179,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_index_files"
-        },
-        "response": {
-          "bodySize": 219,
-          "content": {
-            "mimeType": "application/json",
-            "size": 219,
-            "text": "{\"created_at\":\"2018-08-24T00:06:03Z\",\"id\":\"3ovyFLrfhurRT4VXkjCjaq\",\"deleted_at\":null,\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\",\"write_only\":true,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"name\":\"strain_index_files\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "219"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4078-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.765473,VS0,VE319"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 552,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 552
-        }
-      },
-      {
-        "_id": "ff09c5f3537dbf4e18e3012e11c6c58a",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 186,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_github_static_refs"
-        },
-        "response": {
-          "bodySize": 226,
-          "content": {
-            "mimeType": "application/json",
-            "size": 226,
-            "text": "{\"deleted_at\":null,\"write_only\":true,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"id\":\"5Jdxbb1yW7RnHsZU4r5mF6\",\"created_at\":\"2018-08-03T09:43:31Z\",\"name\":\"strain_github_static_refs\",\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "226"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4060-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.760882,VS0,VE323"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 555,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 555
-        }
-      },
-      {
-        "_id": "d3c99ba68f20a0226d25f5cd6971a0c5",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 173,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_allow"
-        },
-        "response": {
-          "bodySize": 213,
-          "content": {
-            "mimeType": "application/json",
-            "size": 213,
-            "text": "{\"write_only\":true,\"updated_at\":\"2019-07-18T05:36:20Z\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"deleted_at\":null,\"id\":\"3Im6QICsW4nWwmJfXOnkOG\",\"created_at\":\"2018-09-09T20:27:25Z\",\"name\":\"strain_allow\",\"version\":247}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "213"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4036-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.761167,VS0,VE299"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 516,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 516
+          "wait": 477
         }
       },
       {
@@ -1435,7 +630,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 212,
-            "text": "{\"created_at\":\"2018-07-19T16:00:40Z\",\"id\":\"6tS8lvtRx0hWi7PATiYTlg\",\"deleted_at\":null,\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\",\"write_only\":true,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"name\":\"strain_refs\"}"
+            "text": "{\"version\":247,\"created_at\":\"2018-07-19T16:00:40Z\",\"name\":\"strain_refs\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"deleted_at\":null,\"write_only\":true,\"updated_at\":\"2019-07-18T05:36:20Z\",\"id\":\"6tS8lvtRx0hWi7PATiYTlg\"}"
           },
           "cookies": [],
           "headers": [
@@ -1469,7 +664,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
             },
             {
               "name": "connection",
@@ -1477,7 +672,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4053-HHN"
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4031-HHN"
             },
             {
               "name": "x-cache",
@@ -1489,7 +684,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.749943,VS0,VE341"
+              "value": "S1579611892.232629,VS0,VE262"
             },
             {
               "name": "vary",
@@ -1506,8 +701,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 562,
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 480,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1515,11 +710,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 562
+          "wait": 480
         }
       },
       {
-        "_id": "965116eed34cea6c304ec8fa9b1662b7",
+        "_id": "e37f8a48343cda591f65a968582bb678",
         "_order": 0,
         "cache": {},
         "request": {
@@ -1539,18 +734,18 @@
               "value": 0
             }
           ],
-          "headersSize": 187,
+          "headersSize": 173,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_github_static_repos"
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_repos"
         },
         "response": {
-          "bodySize": 227,
+          "bodySize": 213,
           "content": {
             "mimeType": "application/json",
-            "size": 227,
-            "text": "{\"deleted_at\":null,\"id\":\"5JPgAr0Srq1SKY0EnxtrOK\",\"created_at\":\"2018-08-03T09:43:31Z\",\"name\":\"strain_github_static_repos\",\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"write_only\":true}"
+            "size": 213,
+            "text": "{\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"id\":\"6tmoyiJsES3E5YlwmjF8ls\",\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\",\"write_only\":true,\"created_at\":\"2018-07-19T16:00:41Z\",\"deleted_at\":null,\"name\":\"strain_repos\"}"
           },
           "cookies": [],
           "headers": [
@@ -1580,11 +775,11 @@
             },
             {
               "name": "content-length",
-              "value": "227"
+              "value": "213"
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
             },
             {
               "name": "connection",
@@ -1592,7 +787,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4076-HHN"
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4065-HHN"
             },
             {
               "name": "x-cache",
@@ -1604,7 +799,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.759926,VS0,VE342"
+              "value": "S1579611892.240443,VS0,VE260"
             },
             {
               "name": "vary",
@@ -1621,8 +816,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 576,
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 483,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1630,122 +825,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 576
-        }
-      },
-      {
-        "_id": "a11f01965b0d7a0586b53ce5afa47959",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 188,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_github_static_owners"
-        },
-        "response": {
-          "bodySize": 228,
-          "content": {
-            "mimeType": "application/json",
-            "size": 228,
-            "text": "{\"id\":\"5JPU8atUUXBuUOXhK5Zctk\",\"created_at\":\"2018-08-03T09:43:31Z\",\"write_only\":true,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"name\":\"strain_github_static_owners\",\"deleted_at\":null,\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "228"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4061-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.757032,VS0,VE533"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 786,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 786
+          "wait": 483
         }
       },
       {
@@ -1780,7 +860,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 426,
-            "text": "[{\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"name\":\"hlx-pub-redirect-a8c64b42913a5df702c652b83858b0fb0c5b2f97\",\"type\":\"REQUEST\",\"statement\":\"req.http.X-Strain == \\\"default\\\" \\u0026\\u0026 req.url ~ \\\"(.*)\\\\.php\\\"\",\"updated_at\":\"2019-07-18T05:37:01Z\",\"deleted_at\":null,\"version\":\"247\",\"priority\":\"10\",\"created_at\":\"2019-07-18T05:37:01Z\",\"comment\":\"Created by helix-publish for Redirects (a8c64b42913a5df702c652b83858b0fb0c5b2f97)\"}]"
+            "text": "[{\"name\":\"hlx-pub-redirect-a8c64b42913a5df702c652b83858b0fb0c5b2f97\",\"type\":\"REQUEST\",\"deleted_at\":null,\"priority\":\"10\",\"created_at\":\"2019-07-18T05:37:01Z\",\"comment\":\"Created by helix-publish for Redirects (a8c64b42913a5df702c652b83858b0fb0c5b2f97)\",\"updated_at\":\"2019-07-18T05:37:01Z\",\"version\":\"247\",\"statement\":\"req.http.X-Strain == \\\"default\\\" \\u0026\\u0026 req.url ~ \\\"(.*)\\\\.php\\\"\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\"}]"
           },
           "cookies": [],
           "headers": [
@@ -1814,7 +894,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
             },
             {
               "name": "connection",
@@ -1822,7 +902,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4044-HHN"
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4027-HHN"
             },
             {
               "name": "x-cache",
@@ -1834,7 +914,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.757241,VS0,VE325"
+              "value": "S1579611892.236494,VS0,VE266"
             },
             {
               "name": "vary",
@@ -1851,8 +931,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:44.568Z",
-        "time": 546,
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 485,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1860,15 +940,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 546
+          "wait": 485
         }
       },
       {
-        "_id": "632041237cff502dca2909dce1093fa1",
+        "_id": "40004b211648a5136998f08a36b4837c",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1180,
+          "bodySize": 0,
           "cookies": [],
           "headers": [
             {
@@ -1876,30 +956,26 @@
               "value": "api.fastly.com"
             },
             {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
               "name": "accept",
               "value": "application/json"
             },
             {
               "name": "content-length",
-              "value": 1180
+              "value": 0
             }
           ],
-          "headersSize": 220,
+          "headersSize": 172,
           "httpVersion": "HTTP/1.1",
-          "method": "PUT",
+          "method": "GET",
           "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/vcl/extensions.vcl"
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_deny"
         },
         "response": {
-          "bodySize": 1030,
+          "bodySize": 212,
           "content": {
             "mimeType": "application/json",
-            "size": 1030,
-            "text": "{\"content\":\"#\\n# Copyright 2019 Adobe. All rights reserved.\\n# This file is licensed to you under the Apache License, Version 2.0 (the \\\"License\\\");\\n# you may not use this file except in compliance with the License. You may obtain a copy\\n# of the License at http://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software distributed under\\n# the License is distributed on an \\\"AS IS\\\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS\\n# OF ANY KIND, either express or implied. See the License for the specific language\\n# governing permissions and limitations under the License.\\n#\\n\\nsub hlx_type_pipeline_before {}\\nsub hlx_type_pipeline_after {}\\n\\nsub hlx_owner_before {}\\nsub hlx_owner_after {}\\n\\nsub hlx_repo_before {}\\nsub hlx_repo_after {}\\n\\nsub hlx_ref_before {}\\nsub hlx_ref_after {}\\n\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"updated_at\":\"2019-07-18T05:36:20Z\",\"deleted_at\":null,\"created_at\":\"2019-05-21T21:31:07Z\",\"name\":\"extensions.vcl\",\"version\":247,\"main\":false}"
+            "size": 212,
+            "text": "{\"updated_at\":\"2019-07-18T05:36:20Z\",\"version\":247,\"name\":\"strain_deny\",\"id\":\"0Z4tRqFgpgkkMuicA4X32T\",\"deleted_at\":null,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"write_only\":true,\"created_at\":\"2018-09-09T20:27:24Z\"}"
           },
           "cookies": [],
           "headers": [
@@ -1916,28 +992,24 @@
               "value": "no-cache"
             },
             {
-              "name": "fastly-ratelimit-remaining",
-              "value": "990"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
               "name": "accept-ranges",
-              "value": "bytes, bytes"
+              "value": "bytes, bytes, bytes"
             },
             {
               "name": "via",
               "value": "1.1 varnish, 1.1 varnish"
             },
             {
+              "name": "age",
+              "value": "0"
+            },
+            {
               "name": "content-length",
-              "value": "1030"
+              "value": "212"
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
             },
             {
               "name": "connection",
@@ -1945,7 +1017,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4062-HHN"
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4050-HHN"
             },
             {
               "name": "x-cache",
@@ -1957,7 +1029,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.147683,VS0,VE411"
+              "value": "S1579611892.245930,VS0,VE234"
             },
             {
               "name": "vary",
@@ -1968,14 +1040,14 @@
               "value": "max-age=31536000"
             }
           ],
-          "headersSize": 501,
+          "headersSize": 446,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:45.055Z",
-        "time": 528,
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 451,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1983,7 +1055,812 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 528
+          "wait": 451
+        }
+      },
+      {
+        "_id": "a11f01965b0d7a0586b53ce5afa47959",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 188,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_github_static_owners"
+        },
+        "response": {
+          "bodySize": 228,
+          "content": {
+            "mimeType": "application/json",
+            "size": 228,
+            "text": "{\"write_only\":true,\"version\":247,\"name\":\"strain_github_static_owners\",\"id\":\"5JPU8atUUXBuUOXhK5Zctk\",\"updated_at\":\"2019-07-18T05:36:20Z\",\"deleted_at\":null,\"created_at\":\"2018-08-03T09:43:31Z\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "content-length",
+              "value": "228"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4054-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611892.240948,VS0,VE272"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 501,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 501
+        }
+      },
+      {
+        "_id": "ff09c5f3537dbf4e18e3012e11c6c58a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 186,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_github_static_refs"
+        },
+        "response": {
+          "bodySize": 226,
+          "content": {
+            "mimeType": "application/json",
+            "size": 226,
+            "text": "{\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"id\":\"5Jdxbb1yW7RnHsZU4r5mF6\",\"name\":\"strain_github_static_refs\",\"created_at\":\"2018-08-03T09:43:31Z\",\"write_only\":true,\"updated_at\":\"2019-07-18T05:36:20Z\",\"version\":247,\"deleted_at\":null}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "content-length",
+              "value": "226"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4062-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611892.237877,VS0,VE277"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 506,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 506
+        }
+      },
+      {
+        "_id": "d3c99ba68f20a0226d25f5cd6971a0c5",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 173,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_allow"
+        },
+        "response": {
+          "bodySize": 213,
+          "content": {
+            "mimeType": "application/json",
+            "size": 213,
+            "text": "{\"deleted_at\":null,\"name\":\"strain_allow\",\"write_only\":true,\"created_at\":\"2018-09-09T20:27:25Z\",\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"id\":\"3Im6QICsW4nWwmJfXOnkOG\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "content-length",
+              "value": "213"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4034-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611892.244004,VS0,VE289"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 518,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 518
+        }
+      },
+      {
+        "_id": "dd93f420a54ea746bbd8a41f46e86d15",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 180,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_action_roots"
+        },
+        "response": {
+          "bodySize": 220,
+          "content": {
+            "mimeType": "application/json",
+            "size": 220,
+            "text": "{\"name\":\"strain_action_roots\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"version\":247,\"created_at\":\"2018-07-19T16:00:41Z\",\"updated_at\":\"2019-07-18T05:36:20Z\",\"id\":\"6tmAIs0aCfNXF6zsmtNScQ\",\"deleted_at\":null,\"write_only\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "content-length",
+              "value": "220"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4047-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611892.236058,VS0,VE311"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 522,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 522
+        }
+      },
+      {
+        "_id": "dcb1844cc38b212cfae957ac8a15b134",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 178,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_root_paths"
+        },
+        "response": {
+          "bodySize": 218,
+          "content": {
+            "mimeType": "application/json",
+            "size": 218,
+            "text": "{\"name\":\"strain_root_paths\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"version\":247,\"created_at\":\"2018-07-19T16:00:41Z\",\"id\":\"6tmANh9iLMvWGSoWMt2xIe\",\"updated_at\":\"2019-07-18T05:36:20Z\",\"deleted_at\":null,\"write_only\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "content-length",
+              "value": "218"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4070-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611892.287872,VS0,VE295"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 560,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 560
+        }
+      },
+      {
+        "_id": "357c2023ea8e0569ddd980e23a9b2723",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 168,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/secrets"
+        },
+        "response": {
+          "bodySize": 208,
+          "content": {
+            "mimeType": "application/json",
+            "size": 208,
+            "text": "{\"write_only\":true,\"deleted_at\":null,\"updated_at\":\"2019-07-18T05:36:20Z\",\"id\":\"6tlJbZRVUMSvAV6QLUKKrm\",\"created_at\":\"2018-07-19T16:00:41Z\",\"version\":247,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"name\":\"secrets\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "content-length",
+              "value": "208"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4066-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611892.369016,VS0,VE257"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 600,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 600
+        }
+      },
+      {
+        "_id": "965116eed34cea6c304ec8fa9b1662b7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 187,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/dictionary/strain_github_static_repos"
+        },
+        "response": {
+          "bodySize": 227,
+          "content": {
+            "mimeType": "application/json",
+            "size": 227,
+            "text": "{\"version\":247,\"write_only\":true,\"name\":\"strain_github_static_repos\",\"id\":\"5JPgAr0Srq1SKY0EnxtrOK\",\"updated_at\":\"2019-07-18T05:36:20Z\",\"deleted_at\":null,\"created_at\":\"2018-08-03T09:43:31Z\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "content-length",
+              "value": "227"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:52 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4024-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611892.241193,VS0,VE228"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.039Z",
+        "time": 438,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 438
         }
       },
       {
@@ -2022,7 +1899,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 482,
-            "text": "{\"deleted_at\":null,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"created_at\":\"2018-10-29T06:03:05Z\",\"main\":false,\"name\":\"params.vcl\",\"content\":\"# This file handles the URL parameter whitelist\\n# default parameters, can be overridden per strain\\nset req.http.X-Old-Url = req.url;\\nset req.url = querystring.regfilter_except(req.url, \\\"^hlx_.*$\\\");\\nset req.http.X-Encoded-Params = urlencode(req.url.qs);\\nset req.url = req.http.X-Old-Url;\",\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\"}"
+            "text": "{\"content\":\"# This file handles the URL parameter whitelist\\n# default parameters, can be overridden per strain\\nset req.http.X-Old-Url = req.url;\\nset req.url = querystring.regfilter_except(req.url, \\\"^hlx_.*$\\\");\\nset req.http.X-Encoded-Params = urlencode(req.url.qs);\\nset req.url = req.http.X-Old-Url;\",\"name\":\"params.vcl\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"created_at\":\"2018-10-29T06:03:05Z\",\"version\":247,\"updated_at\":\"2019-07-18T05:36:20Z\",\"main\":false,\"deleted_at\":null}"
           },
           "cookies": [],
           "headers": [
@@ -2040,11 +1917,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "988"
+              "value": "926"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -2060,7 +1937,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
             },
             {
               "name": "connection",
@@ -2068,7 +1945,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4031-HHN"
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4023-HHN"
             },
             {
               "name": "x-cache",
@@ -2080,7 +1957,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.156995,VS0,VE401"
+              "value": "S1579611893.531233,VS0,VE474"
             },
             {
               "name": "vary",
@@ -2097,8 +1974,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:45.065Z",
-        "time": 514,
+        "startedDateTime": "2020-01-21T13:04:52.439Z",
+        "time": 580,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2106,130 +1983,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 514
-        }
-      },
-      {
-        "_id": "9a2f0f3c3632580104bddd4f9f7cbccb",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 846,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 846
-            }
-          ],
-          "headersSize": 216,
-          "httpVersion": "HTTP/1.1",
-          "method": "PUT",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/vcl/strains.vcl"
-        },
-        "response": {
-          "bodySize": 752,
-          "content": {
-            "mimeType": "application/json",
-            "size": 752,
-            "text": "{\"updated_at\":\"2019-07-18T05:37:01Z\",\"main\":false,\"version\":247,\"deleted_at\":null,\"name\":\"strains.vcl\",\"content\":\"# This file handles the strain resolution\\nset req.http.X-Root-Path = \\\"\\\";\\nif (req.http.Host == \\\"www.project-helix.io\\\" \\u0026\\u0026 (req.http.X-FullDirname ~ \\\"^/cli$\\\" || req.http.X-FullDirname ~ \\\"^/cli/\\\")) {\\n  set req.http.X-Dirname = regsub(req.http.X-FullDirname, \\\"^/cli\\\", \\\"\\\");\\n  set req.http.X-Root-Path = \\\"/cli\\\";\\n  # Rewrite the URL to include the proxy path\\n  set req.url = regsub(req.url, \\\"^/cli\\\", \\\"/\\\");\\n  set req.http.X-Sticky = \\\"false\\\";\\n  set req.http.X-Strain = \\\"default\\\";\\n} else {\\n  set req.http.X-Strain = \\\"default\\\";\\n}\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"created_at\":\"2018-07-19T16:00:40Z\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "987"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "752"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4039-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.157126,VS0,VE398"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.065Z",
-        "time": 512,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 512
+          "wait": 580
         }
       },
       {
@@ -2268,7 +2022,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 1063,
-            "text": "{\"deleted_at\":null,\"created_at\":\"2018-12-13T19:17:08Z\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"name\":\"reset.vcl\",\"main\":false,\"updated_at\":\"2020-01-13T16:52:15Z\",\"version\":247,\"content\":\"# This file resets shielding for all known backends\\nif (req.backend == F_GitHub \\u0026\\u0026 req.restarts == 0) {\\n  if (server.identity !~ \\\"-IAD$\\\" \\u0026\\u0026 req.http.Fastly-FF !~ \\\"-IAD\\\") {\\n    set req.backend = ssl_shield_iad_va_us;\\n  }\\n  if (!req.backend.healthy) {\\n    set req.backend = F_GitHub;\\n  }\\n}\\nif (req.backend == F_AdobeRuntime \\u0026\\u0026 req.restarts == 0) {\\n  if (server.identity !~ \\\"-IAD$\\\" \\u0026\\u0026 req.http.Fastly-FF !~ \\\"-IAD\\\") {\\n    set req.backend = ssl_shield_iad_va_us;\\n  }\\n  if (!req.backend.healthy) {\\n    set req.backend = F_AdobeRuntime;\\n  }\\n}\\nif (req.backend == F_AzureBlobs \\u0026\\u0026 req.restarts == 0) {\\n  if (server.identity !~ \\\"-IAD$\\\" \\u0026\\u0026 req.http.Fastly-FF !~ \\\"-IAD\\\") {\\n    set req.backend = ssl_shield_iad_va_us;\\n  }\\n  if (!req.backend.healthy) {\\n    set req.backend = F_AzureBlobs;\\n  }\\n}\"}"
+            "text": "{\"created_at\":\"2018-12-13T19:17:08Z\",\"updated_at\":\"2020-01-13T16:52:15Z\",\"version\":247,\"name\":\"reset.vcl\",\"deleted_at\":null,\"main\":false,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"content\":\"# This file resets shielding for all known backends\\nif (req.backend == F_GitHub \\u0026\\u0026 req.restarts == 0) {\\n  if (server.identity !~ \\\"-IAD$\\\" \\u0026\\u0026 req.http.Fastly-FF !~ \\\"-IAD\\\") {\\n    set req.backend = ssl_shield_iad_va_us;\\n  }\\n  if (!req.backend.healthy) {\\n    set req.backend = F_GitHub;\\n  }\\n}\\nif (req.backend == F_AdobeRuntime \\u0026\\u0026 req.restarts == 0) {\\n  if (server.identity !~ \\\"-IAD$\\\" \\u0026\\u0026 req.http.Fastly-FF !~ \\\"-IAD\\\") {\\n    set req.backend = ssl_shield_iad_va_us;\\n  }\\n  if (!req.backend.healthy) {\\n    set req.backend = F_AdobeRuntime;\\n  }\\n}\\nif (req.backend == F_AzureBlobs \\u0026\\u0026 req.restarts == 0) {\\n  if (server.identity !~ \\\"-IAD$\\\" \\u0026\\u0026 req.http.Fastly-FF !~ \\\"-IAD\\\") {\\n    set req.backend = ssl_shield_iad_va_us;\\n  }\\n  if (!req.backend.healthy) {\\n    set req.backend = F_AzureBlobs;\\n  }\\n}\"}"
           },
           "cookies": [],
           "headers": [
@@ -2286,11 +2040,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "989"
+              "value": "927"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -2306,7 +2060,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
             },
             {
               "name": "connection",
@@ -2314,7 +2068,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4057-HHN"
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4023-HHN"
             },
             {
               "name": "x-cache",
@@ -2326,7 +2080,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.151524,VS0,VE405"
+              "value": "S1579611893.517600,VS0,VE496"
             },
             {
               "name": "vary",
@@ -2343,8 +2097,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:45.075Z",
-        "time": 512,
+        "startedDateTime": "2020-01-21T13:04:52.439Z",
+        "time": 599,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2352,7 +2106,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 512
+          "wait": 599
         }
       },
       {
@@ -2391,7 +2145,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 357,
-            "text": "{\"content\":\"# This file shows the current version\\nset req.http.X-Version = req.http.X-Version + \\\"; src=247; cli=3.0.4; rev=online\\\";\\nset req.http.X-Dispatch-Version = \\\"v3\\\";\\n\",\"version\":247,\"updated_at\":\"2020-01-13T16:52:15Z\",\"name\":\"dynamic.vcl\",\"main\":false,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"created_at\":\"2018-10-29T06:03:06Z\",\"deleted_at\":null}"
+            "text": "{\"created_at\":\"2018-10-29T06:03:06Z\",\"name\":\"dynamic.vcl\",\"main\":false,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"deleted_at\":null,\"content\":\"# This file shows the current version\\nset req.http.X-Version = req.http.X-Version + \\\"; src=247; cli=3.1.0; rev=online\\\";\\nset req.http.X-Dispatch-Version = \\\"v3\\\";\\n\",\"version\":247,\"updated_at\":\"2020-01-21T13:02:10Z\"}"
           },
           "cookies": [],
           "headers": [
@@ -2409,11 +2163,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "986"
+              "value": "922"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -2429,7 +2183,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
             },
             {
               "name": "connection",
@@ -2437,7 +2191,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4023-HHN"
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4027-HHN"
             },
             {
               "name": "x-cache",
@@ -2449,7 +2203,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.155132,VS0,VE400"
+              "value": "S1579611893.547548,VS0,VE464"
             },
             {
               "name": "vary",
@@ -2466,8 +2220,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:45.075Z",
-        "time": 507,
+        "startedDateTime": "2020-01-21T13:04:52.463Z",
+        "time": 569,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2475,130 +2229,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 507
+          "wait": 569
         }
       },
       {
-        "_id": "f48382ba69599679c71be0dd20353e59",
+        "_id": "632041237cff502dca2909dce1093fa1",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 0
-            }
-          ],
-          "headersSize": 156,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/header"
-        },
-        "response": {
-          "bodySize": 502,
-          "content": {
-            "mimeType": "application/json",
-            "size": 502,
-            "text": "[{\"dst\":\"http.X-Location\",\"updated_at\":\"2019-07-18T05:37:02Z\",\"regex\":\"\",\"cache_condition\":null,\"response_condition\":null,\"request_condition\":\"hlx-pub-redirect-a8c64b42913a5df702c652b83858b0fb0c5b2f97\",\"action\":\"set\",\"deleted_at\":null,\"name\":\"hlx-pub-redirect-a88736bb00e18da1e01d40120b1da1149a108b58\",\"version\":\"247\",\"ignore_if_set\":\"0\",\"created_at\":\"2019-07-18T05:37:02Z\",\"substitution\":\"\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"priority\":\"10\",\"type\":\"request\",\"src\":\"\\\"\\\" + re.group.1 + \\\".html\\\"\"}]"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "age",
-              "value": "0"
-            },
-            {
-              "name": "content-length",
-              "value": "502"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4073-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.203373,VS0,VE261"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 446,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.136Z",
-        "time": 357,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 357
-        }
-      },
-      {
-        "_id": "33674037d5d6fce9836f2c9249bceab8",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 275,
+          "bodySize": 1180,
           "cookies": [],
           "headers": [
             {
@@ -2615,21 +2254,21 @@
             },
             {
               "name": "content-length",
-              "value": 275
+              "value": 1180
             }
           ],
-          "headersSize": 215,
+          "headersSize": 220,
           "httpVersion": "HTTP/1.1",
           "method": "PUT",
           "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/backend/GitHub"
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/vcl/extensions.vcl"
         },
         "response": {
-          "bodySize": 794,
+          "bodySize": 1030,
           "content": {
             "mimeType": "application/json",
-            "size": 794,
-            "text": "{\"healthcheck\":null,\"auto_loadbalance\":false,\"created_at\":\"2018-07-19T16:00:40Z\",\"name\":\"GitHub\",\"version\":247,\"ssl_client_cert\":null,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"shield\":\"iad-va-us\",\"connect_timeout\":1000,\"ssl_sni_hostname\":null,\"min_tls_version\":null,\"error_threshold\":0,\"hostname\":\"raw.githubusercontent.com\",\"first_byte_timeout\":15000,\"between_bytes_timeout\":10000,\"updated_at\":\"2019-07-18T05:36:20Z\",\"max_conn\":200,\"address\":\"raw.githubusercontent.com\",\"max_tls_version\":null,\"request_condition\":\"\",\"override_host\":null,\"port\":443,\"ssl_ciphers\":null,\"client_cert\":null,\"ssl_cert_hostname\":\"githubusercontent.com\",\"use_ssl\":true,\"ssl_ca_cert\":null,\"ipv6\":null,\"comment\":\"\",\"ssl_check_cert\":true,\"ssl_hostname\":null,\"ssl_client_key\":null,\"ipv4\":null,\"weight\":100,\"deleted_at\":null}"
+            "size": 1030,
+            "text": "{\"created_at\":\"2019-05-21T21:31:07Z\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"deleted_at\":null,\"main\":false,\"name\":\"extensions.vcl\",\"content\":\"#\\n# Copyright 2019 Adobe. All rights reserved.\\n# This file is licensed to you under the Apache License, Version 2.0 (the \\\"License\\\");\\n# you may not use this file except in compliance with the License. You may obtain a copy\\n# of the License at http://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software distributed under\\n# the License is distributed on an \\\"AS IS\\\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS\\n# OF ANY KIND, either express or implied. See the License for the specific language\\n# governing permissions and limitations under the License.\\n#\\n\\nsub hlx_type_pipeline_before {}\\nsub hlx_type_pipeline_after {}\\n\\nsub hlx_owner_before {}\\nsub hlx_owner_after {}\\n\\nsub hlx_repo_before {}\\nsub hlx_repo_after {}\\n\\nsub hlx_ref_before {}\\nsub hlx_ref_after {}\\n\",\"updated_at\":\"2019-07-18T05:36:20Z\",\"version\":247}"
           },
           "cookies": [],
           "headers": [
@@ -2647,11 +2286,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "971"
+              "value": "925"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -2663,11 +2302,11 @@
             },
             {
               "name": "content-length",
-              "value": "794"
+              "value": "1030"
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:46 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
             },
             {
               "name": "connection",
@@ -2675,7 +2314,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4065-HHN"
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4039-HHN"
             },
             {
               "name": "x-cache",
@@ -2687,7 +2326,130 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.207710,VS0,VE834"
+              "value": "S1579611893.539681,VS0,VE487"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 501,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.463Z",
+        "time": 578,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 578
+        }
+      },
+      {
+        "_id": "9a2f0f3c3632580104bddd4f9f7cbccb",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 846,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 846
+            }
+          ],
+          "headersSize": 216,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/vcl/strains.vcl"
+        },
+        "response": {
+          "bodySize": 752,
+          "content": {
+            "mimeType": "application/json",
+            "size": 752,
+            "text": "{\"created_at\":\"2018-07-19T16:00:40Z\",\"main\":false,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"deleted_at\":null,\"content\":\"# This file handles the strain resolution\\nset req.http.X-Root-Path = \\\"\\\";\\nif (req.http.Host == \\\"www.project-helix.io\\\" \\u0026\\u0026 (req.http.X-FullDirname ~ \\\"^/cli$\\\" || req.http.X-FullDirname ~ \\\"^/cli/\\\")) {\\n  set req.http.X-Dirname = regsub(req.http.X-FullDirname, \\\"^/cli\\\", \\\"\\\");\\n  set req.http.X-Root-Path = \\\"/cli\\\";\\n  # Rewrite the URL to include the proxy path\\n  set req.url = regsub(req.url, \\\"^/cli\\\", \\\"/\\\");\\n  set req.http.X-Sticky = \\\"false\\\";\\n  set req.http.X-Strain = \\\"default\\\";\\n} else {\\n  set req.http.X-Strain = \\\"default\\\";\\n}\",\"version\":247,\"updated_at\":\"2019-07-18T05:37:01Z\",\"name\":\"strains.vcl\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "924"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "752"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4071-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.541469,VS0,VE562"
             },
             {
               "name": "vary",
@@ -2704,8 +2466,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:45.136Z",
-        "time": 1005,
+        "startedDateTime": "2020-01-21T13:04:52.463Z",
+        "time": 654,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2713,7 +2475,130 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1005
+          "wait": 654
+        }
+      },
+      {
+        "_id": "504aaa6ab86faa125d6efed82c49543e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1689,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 1689
+            }
+          ],
+          "headersSize": 217,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/vcl/queries.vcl"
+        },
+        "response": {
+          "bodySize": 1249,
+          "content": {
+            "mimeType": "application/json",
+            "size": 1249,
+            "text": "{\"name\":\"queries.vcl\",\"deleted_at\":null,\"updated_at\":\"2020-01-21T13:02:09Z\",\"version\":247,\"created_at\":\"2020-01-21T13:02:09Z\",\"content\":\"if (req.url.path == \\\"/_query/blog-posts/all\\\") {\\n  set req.http.X-Surrogate-Control = \\\"max-age=600\\\";\\n  set req.http.X-Backend-URL = \\\"/1/indexes/\\\"\\n   + req.http.X-Owner + \\\"--\\\"\\n   + req.http.X-Repo + \\\"--\\\"\\n   + \\\"blog-posts\\\" # from the index name\\n   + \\\"?query=\\\" + \\\"*\\\"\\n   + \\\"\\u0026filters=\\\" + \\\"\\\"\\n   + \\\"\\u0026facets=\\\" + \\\"\\\"\\n   + \\\"\\u0026page=\\\" + regsub(querystring.filter_except(req.url, \\\"page\\\"), \\\"^[^=]*=?\\\", \\\"\\\")\\n   + \\\"\\u0026hitsPerPage=25\\\";\\n}\\nif (req.url.path == \\\"/_query/blog-posts/by-author\\\") {\\n  set req.http.X-Surrogate-Control = \\\"max-age=300\\\";\\n  set req.http.X-Backend-URL = \\\"/1/indexes/\\\"\\n   + req.http.X-Owner + \\\"--\\\"\\n   + req.http.X-Repo + \\\"--\\\"\\n   + \\\"blog-posts\\\" # from the index name\\n   + \\\"?query=\\\" + \\\"*\\\"\\n   + \\\"\\u0026filters=\\\" + \\\"author%3A\\\" + regsub(querystring.filter_except(req.url, \\\"author\\\"), \\\"^[^=]*=?\\\", \\\"\\\") + \\\"\\\"\\n   + \\\"\\u0026facets=\\\" + \\\"\\\"\\n   + \\\"\\u0026page=\\\" + regsub(querystring.filter_except(req.url, \\\"page\\\"), \\\"^[^=]*=?\\\", \\\"\\\")\\n   + \\\"\\u0026hitsPerPage=25\\\";\\n}\",\"main\":false,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "923"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "1249"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4021-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.570158,VS0,VE445"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 501,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.484Z",
+        "time": 552,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 552
         }
       },
       {
@@ -2752,18 +2637,10 @@
           "content": {
             "mimeType": "application/json",
             "size": 783,
-            "text": "{\"ssl_hostname\":null,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"use_ssl\":true,\"between_bytes_timeout\":10000,\"override_host\":null,\"hostname\":\"adobeioruntime.net\",\"ssl_ciphers\":null,\"name\":\"AdobeRuntime\",\"ssl_sni_hostname\":null,\"updated_at\":\"2019-07-18T05:36:20Z\",\"version\":247,\"ssl_check_cert\":true,\"max_tls_version\":null,\"ssl_client_key\":null,\"request_condition\":\"\",\"max_conn\":200,\"weight\":100,\"ipv4\":null,\"min_tls_version\":null,\"connect_timeout\":1000,\"port\":443,\"address\":\"adobeioruntime.net\",\"ssl_cert_hostname\":\"adobeioruntime.net\",\"ssl_ca_cert\":null,\"healthcheck\":null,\"auto_loadbalance\":false,\"error_threshold\":0,\"deleted_at\":null,\"ssl_client_cert\":null,\"ipv6\":null,\"first_byte_timeout\":60000,\"created_at\":\"2018-09-10T08:33:49Z\",\"client_cert\":null,\"comment\":\"\",\"shield\":\"iad-va-us\"}"
+            "text": "{\"first_byte_timeout\":60000,\"ssl_cert_hostname\":\"adobeioruntime.net\",\"created_at\":\"2018-09-10T08:33:49Z\",\"comment\":\"\",\"address\":\"adobeioruntime.net\",\"healthcheck\":null,\"shield\":\"iad-va-us\",\"client_cert\":null,\"error_threshold\":0,\"ipv4\":null,\"ipv6\":null,\"version\":247,\"between_bytes_timeout\":10000,\"auto_loadbalance\":false,\"max_tls_version\":null,\"request_condition\":\"\",\"hostname\":\"adobeioruntime.net\",\"ssl_ciphers\":null,\"override_host\":null,\"weight\":100,\"ssl_check_cert\":true,\"port\":443,\"ssl_client_cert\":null,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"deleted_at\":null,\"updated_at\":\"2019-07-18T05:36:20Z\",\"min_tls_version\":null,\"max_conn\":200,\"use_ssl\":true,\"ssl_ca_cert\":null,\"ssl_sni_hostname\":null,\"ssl_client_key\":null,\"connect_timeout\":1000,\"name\":\"AdobeRuntime\",\"ssl_hostname\":null}"
           },
           "cookies": [],
           "headers": [
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "content-length",
-              "value": "783"
-            },
             {
               "name": "status",
               "value": "200 OK"
@@ -2778,11 +2655,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "985"
+              "value": "921"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -2793,12 +2670,20 @@
               "value": "1.1 varnish, 1.1 varnish"
             },
             {
+              "name": "content-length",
+              "value": "783"
+            },
+            {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4029-HHN"
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4044-HHN"
             },
             {
               "name": "x-cache",
@@ -2810,7 +2695,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.207751,VS0,VE350"
+              "value": "S1579611893.577550,VS0,VE435"
             },
             {
               "name": "vary",
@@ -2827,8 +2712,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:45.136Z",
-        "time": 449,
+        "startedDateTime": "2020-01-21T13:04:52.503Z",
+        "time": 531,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2836,7 +2721,368 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 449
+          "wait": 531
+        }
+      },
+      {
+        "_id": "0e0f158bdf0cf6ac82a46b5a692f33ba",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 283,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 283
+            }
+          ],
+          "headersSize": 216,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/backend/Algolia"
+        },
+        "response": {
+          "bodySize": 802,
+          "content": {
+            "mimeType": "application/json",
+            "size": 802,
+            "text": "{\"request_condition\":\"\",\"error_threshold\":0,\"deleted_at\":null,\"port\":443,\"version\":247,\"weight\":100,\"address\":\"A8PL9E4TZT-dsn.algolia.net\",\"max_conn\":200,\"ssl_cert_hostname\":\"A8PL9E4TZT-dsn.algolia.net\",\"created_at\":\"2020-01-21T13:02:09Z\",\"connect_timeout\":1000,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"min_tls_version\":null,\"ssl_client_cert\":null,\"hostname\":\"A8PL9E4TZT-dsn.algolia.net\",\"updated_at\":\"2020-01-21T13:02:09Z\",\"ssl_hostname\":null,\"ipv4\":null,\"ipv6\":null,\"max_tls_version\":null,\"ssl_sni_hostname\":null,\"between_bytes_timeout\":10000,\"ssl_check_cert\":true,\"shield\":\"iad-va-us\",\"ssl_ciphers\":null,\"name\":\"Algolia\",\"client_cert\":null,\"override_host\":null,\"use_ssl\":true,\"comment\":\"\",\"first_byte_timeout\":60000,\"ssl_client_key\":null,\"ssl_ca_cert\":null,\"healthcheck\":null,\"auto_loadbalance\":false}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "920"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "802"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4069-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.605452,VS0,VE397"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.512Z",
+        "time": 509,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 509
+        }
+      },
+      {
+        "_id": "f48382ba69599679c71be0dd20353e59",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 0
+            }
+          ],
+          "headersSize": 156,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/header"
+        },
+        "response": {
+          "bodySize": 502,
+          "content": {
+            "mimeType": "application/json",
+            "size": 502,
+            "text": "[{\"name\":\"hlx-pub-redirect-a88736bb00e18da1e01d40120b1da1149a108b58\",\"substitution\":\"\",\"version\":\"247\",\"type\":\"request\",\"src\":\"\\\"\\\" + re.group.1 + \\\".html\\\"\",\"ignore_if_set\":\"0\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"priority\":\"10\",\"created_at\":\"2019-07-18T05:37:02Z\",\"updated_at\":\"2019-07-18T05:37:02Z\",\"cache_condition\":null,\"response_condition\":null,\"action\":\"set\",\"dst\":\"http.X-Location\",\"request_condition\":\"hlx-pub-redirect-a8c64b42913a5df702c652b83858b0fb0c5b2f97\",\"deleted_at\":null,\"regex\":\"\"}]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "content-length",
+              "value": "502"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4082-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.608790,VS0,VE477"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.530Z",
+        "time": 566,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 566
+        }
+      },
+      {
+        "_id": "33674037d5d6fce9836f2c9249bceab8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 275,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 275
+            }
+          ],
+          "headersSize": 215,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/backend/GitHub"
+        },
+        "response": {
+          "bodySize": 794,
+          "content": {
+            "mimeType": "application/json",
+            "size": 794,
+            "text": "{\"auto_loadbalance\":false,\"healthcheck\":null,\"ssl_ca_cert\":null,\"ssl_client_key\":null,\"first_byte_timeout\":15000,\"comment\":\"\",\"use_ssl\":true,\"override_host\":null,\"client_cert\":null,\"name\":\"GitHub\",\"shield\":\"iad-va-us\",\"ssl_ciphers\":null,\"ssl_check_cert\":true,\"between_bytes_timeout\":10000,\"ssl_sni_hostname\":null,\"ipv6\":null,\"max_tls_version\":null,\"ipv4\":null,\"ssl_hostname\":null,\"updated_at\":\"2019-07-18T05:36:20Z\",\"hostname\":\"raw.githubusercontent.com\",\"min_tls_version\":null,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"ssl_client_cert\":null,\"connect_timeout\":1000,\"created_at\":\"2018-07-19T16:00:40Z\",\"ssl_cert_hostname\":\"githubusercontent.com\",\"max_conn\":200,\"address\":\"raw.githubusercontent.com\",\"weight\":100,\"version\":247,\"port\":443,\"deleted_at\":null,\"error_threshold\":0,\"request_condition\":\"\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "919"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "794"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4067-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.607688,VS0,VE732"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.550Z",
+        "time": 857,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 857
         }
       },
       {
@@ -2875,7 +3121,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 802,
-            "text": "{\"ssl_cert_hostname\":\"hlx.blob.core.windows.net\",\"error_threshold\":0,\"created_at\":\"2020-01-13T16:58:14Z\",\"client_cert\":null,\"version\":247,\"first_byte_timeout\":60000,\"port\":443,\"healthcheck\":null,\"ssl_client_cert\":null,\"ipv6\":null,\"connect_timeout\":1000,\"hostname\":\"hlx.blob.core.windows.net\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"use_ssl\":true,\"min_tls_version\":null,\"override_host\":null,\"comment\":\"\",\"ssl_sni_hostname\":null,\"max_tls_version\":null,\"ssl_hostname\":null,\"name\":\"AzureBlobs\",\"deleted_at\":null,\"shield\":\"iad-va-us\",\"auto_loadbalance\":false,\"max_conn\":200,\"updated_at\":\"2020-01-13T16:58:14Z\",\"ssl_check_cert\":true,\"address\":\"hlx.blob.core.windows.net\",\"ssl_ca_cert\":null,\"request_condition\":\"\",\"ssl_client_key\":null,\"weight\":100,\"ipv4\":null,\"ssl_ciphers\":null,\"between_bytes_timeout\":10000}"
+            "text": "{\"first_byte_timeout\":60000,\"hostname\":\"hlx.blob.core.windows.net\",\"ssl_hostname\":null,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"max_tls_version\":null,\"min_tls_version\":null,\"name\":\"AzureBlobs\",\"created_at\":\"2020-01-13T16:58:14Z\",\"ssl_check_cert\":true,\"weight\":100,\"ssl_ciphers\":null,\"ssl_client_cert\":null,\"request_condition\":\"\",\"auto_loadbalance\":false,\"max_conn\":200,\"healthcheck\":null,\"deleted_at\":null,\"between_bytes_timeout\":10000,\"error_threshold\":0,\"ssl_client_key\":null,\"ipv6\":null,\"client_cert\":null,\"connect_timeout\":1000,\"shield\":\"iad-va-us\",\"ssl_cert_hostname\":\"hlx.blob.core.windows.net\",\"updated_at\":\"2020-01-13T16:58:14Z\",\"override_host\":null,\"port\":443,\"version\":247,\"address\":\"hlx.blob.core.windows.net\",\"comment\":\"\",\"ssl_ca_cert\":null,\"use_ssl\":true,\"ipv4\":null,\"ssl_sni_hostname\":null}"
           },
           "cookies": [],
           "headers": [
@@ -2893,11 +3139,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "984"
+              "value": "918"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -2913,7 +3159,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:45 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
             },
             {
               "name": "connection",
@@ -2921,7 +3167,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4077-HHN"
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4034-HHN"
             },
             {
               "name": "x-cache",
@@ -2933,7 +3179,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.205837,VS0,VE491"
+              "value": "S1579611893.610415,VS0,VE733"
             },
             {
               "name": "vary",
@@ -2950,8 +3196,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:45.147Z",
-        "time": 575,
+        "startedDateTime": "2020-01-21T13:04:52.550Z",
+        "time": 859,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2959,1360 +3205,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 575
-        }
-      },
-      {
-        "_id": "78c79d98212ed3d15368cf37bdd7c7b4",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 178125,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "content-type",
-              "value": "application/x-www-form-urlencoded"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 178125
-            }
-          ],
-          "headersSize": 217,
-          "httpVersion": "HTTP/1.1",
-          "method": "PUT",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/vcl/helix.vcl"
-        },
-        "response": {
-          "bodySize": 102510,
-          "content": {
-            "mimeType": "application/json",
-            "size": 102510,
-            "text": "{\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"content\":\"#\\n# Copyright 2018 Adobe. All rights reserved.\\n# This file is licensed to you under the Apache License, Version 2.0 (the \\\"License\\\");\\n# you may not use this file except in compliance with the License. You may obtain a copy\\n# of the License at http://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software distributed under\\n# the License is distributed on an \\\"AS IS\\\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS\\n# OF ANY KIND, either express or implied. See the License for the specific language\\n# governing permissions and limitations under the License.\\n#\\n\\n\\n# About URLs and Host headers:\\n# This VCL will use the following conventions:\\n# `req.url` - The canonical URL, will be used to determine the hash of the object\\n# `req.http.X-Orig-URL` - The URL as received from the client\\n# `req.http.X-Backend-URL` - The URL as should be sent to the origin (backend)\\n#\\n# Having `req.url` be canonical, vs `X-Backend-URL` being what's sent to origin\\n# allows us to do restarts to find content on other origins, and use origin\\n# specific URLs, yet have the object stored under a single hash, meaning that\\n# a cache lookup will find the proper object on the first attempt once an\\n# object is in the cache.\\n#\\n# So `req.url` is what should be left after filtering query string parameters,\\n# doing normalizations, etc. Then `req.http.X-Backend-URL` is a transformation of\\n# that, using the origin specific rewriting, etc.\\n#\\n# Domain names are handled a bit simpler:\\n# `req.http.Host` - The canonical domain name for the site, used for the hash\\n# `req.http.X-Orig-Host` - The original domain name from the client\\n#\\n# `bereq.http.Host` will be set based on the backend used.\\n#\\n# When forwarding the request from edge POP to shield POP, the original URL and\\n# original domain name will be used.\\n\\n# VCL extension points\\ninclude \\\"extensions.vcl\\\";\\n\\n/**\\n * Check the `X-From-Edge` header, which allows us to determine whether\\n * a request is coming from a Fastly edge POP. Use this instead of `Fastly-FF`\\n * since that can be spoofed, or come from another Fastly service.\\n *\\n * This should be called from the very top of `vcl_recv`\\n */\\nsub hlx_check_from_edge {\\n  # Verify correct format\\n  if (req.http.X-From-Edge ~ \\\"^(([0-9]+),[^,]+),(0x[0-9a-f]{64})$\\\"\\n      # Verify the HMAC\\n      \\u0026\\u0026 digest.secure_is_equal(\\n           # Using existing secret, but adding it to service id\\n           # TODO: use a separate secret, because changing it can have some\\n           # gnarly effects, if you don't follow it with a purge all\\n           digest.hmac_sha256(req.service_id + table.lookup(secrets, \\\"OPENWHISK_AUTH\\\")\\n           , re.group.1), re.group.3)) {\\n    declare local var.time TIME;\\n    set var.time = std.time(re.group.2, std.integer2time(-1));\\n    # And verify the timestamp is not off by more than 2 seconds\\n    if (time.is_after(var.time, time.sub(now, 2s))\\n        \\u0026\\u0026 time.is_after(time.add(now, 2s), var.time)) {\\n      # Do nothing, the header is valid\\n      return;\\n    }\\n  }\\n  # Header isn't valid, chuck it\\n  unset req.http.X-From-Edge;\\n}\\n\\n/**\\n * Set the `X-From-Edge` header that the above sub checks.\\n *\\n * Should be called from the top of `vcl_miss`/`vcl_pass`\\n */\\nsub hlx_set_from_edge {\\n  # If it exists, it's legit, leave it alone\\n  if (!bereq.http.X-From-Edge) {\\n    declare local var.data STRING;\\n    set var.data = strftime({\\\"%s\\\"}, now) + \\\",\\\" + server.datacenter;\\n    set bereq.http.X-From-Edge =\\n      var.data + \\\",\\\" + digest.hmac_sha256(\\n        # This must match whatever key is being used\\n        req.service_id + table.lookup(secrets, \\\"OPENWHISK_AUTH\\\"), var.data);\\n  }\\n}\\n\\n/**\\n * Initial processing of request\\n * Does:\\n * - Save original URL/Host\\n * - Unset headers from client\\n * - Setup secure shielding indicator\\n */\\n\\nsub hlx_recv_init {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_recv_init\\\";\\n\\n  # This is set to true for some cases, but that is not cleared upon a restart\\n  set req.hash_always_miss = false;\\n\\n  # Execute the rest only at the very start, not after restarts\\n  if (req.restarts \\u003e 0) {\\n    return;\\n  }\\n\\n  # Check/clear X-From-Edge header\\n  call hlx_check_from_edge;\\n\\n  # Set original URL, so that we can log it afterwards.\\n  set req.http.X-Orig-URL = req.url;\\n  set req.http.X-Orig-Host = req.http.Host;\\n\\n  if (!req.http.X-Debug) {\\n    # Make sure clients can't change request flow\\n    # X-Strain is currently settable by Cookie, not worth unsetting for now\\n    unset req.http.X-Backend-URL;\\n    unset req.http.X-Dirname;\\n    unset req.http.X-Request-Type;\\n    unset req.http.X-Static-Content-Type;\\n    unset req.http.X-Sticky;\\n    # Allow through from another Fastly POP as well as from debugger\\n    if (!req.http.X-From-Edge) {\\n      unset req.http.X-CDN-Request-ID;\\n    }\\n  }\\n\\n  # Force HTTPS\\n  if (!req.http.Fastly-SSL) {\\n     error 801 \\\"Force SSL\\\";\\n  }\\n\\n  # Set a unique ID if not present\\n  if (!req.http.X-CDN-Request-ID) {\\n    set req.http.X-CDN-Request-ID = randomstr(8, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(4, \\\"0123456789abcdef\\\") + \\\"-4\\\" + randomstr(3, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(1, \\\"89ab\\\") + randomstr(3, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(12, \\\"0123456789abcdef\\\");\\n  }\\n\\n  # set X-Version initial value\\n  set req.http.X-Version = regsub(req.vcl, \\\"([^.]+)\\\\.(\\\\d+)_(\\\\d+)-(.*)\\\", \\\"\\\\2\\\");\\n\\n}\\n\\n\\n# Determines the current strain, and sets the X-Strain header\\nsub hlx_strain {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_strain\\\";\\n  # TODO: add X-Strain-Key as a random-generated, validation property\\n  if (req.http.X-Strain) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(header:\\\" + req.http.X-Strain + \\\")\\\";\\n  }\\n  # read strain from URL query string\\n  if (subfield(req.url.qs, \\\"hlx_strain\\\", \\\"\\u0026\\\")) {\\n    set req.http.X-Strain = subfield(req.url.qs, \\\"hlx_strain\\\", \\\"\\u0026\\\");\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(url)\\\";\\n  }\\n  # read strain from Cookie\\n  if (req.http.Cookie:X-Strain) {\\n    set req.http.X-Strain = req.http.Cookie:X-Strain;\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(cookie)\\\";\\n  }\\n\\n  # Sanitize user input. `urlencode` leaves alphanumeric and `-._~`\\n  set req.http.X-Strain = regsuball(urlencode(req.http.X-Strain), {\\\"%..\\\"}, \\\"_\\\");\\n\\n  # do not override strain if set in header\\n  if (!req.http.X-Strain||req.http.X-Strain==\\\"\\\") {\\n    set req.http.X-Strain = \\\"default\\\";\\n\\n    # run custom strain resolution\\n    include \\\"strains.vcl\\\";\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(resolved)\\\";\\n  }\\n\\n  # we don't need cookies for anything else, but Proxy strains might\\n  if (req.http.X-Request-Type != \\\"Proxy\\\") {\\n    unset req.http.Cookie;\\n  }\\n}\\n\\n# Gets the content whitelist for the current strain and sets the X-Allow header\\nsub hlx_allow {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_allow\\\";\\n\\n  # starting permissive – change this for a more restrictive default\\n  set req.http.X-Allow = table.lookup(strain_allow, req.http.X-Strain);\\n  if (!req.http.X-Allow) {\\n    set req.http.X-Allow = table.lookup(strain_allow, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the content blacklist for the current strain and sets the X-Deny header\\nsub hlx_deny {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deny\\\";\\n\\n  set req.http.X-Deny = table.lookup(strain_deny, req.http.X-Strain);\\n  if (!req.http.X-Deny) {\\n    set req.http.X-Deny = table.lookup(strain_deny, \\\"default\\\");\\n  }\\n}\\n\\n# Implements the content block list (to be called from vcl_recv)\\nsub hlx_block_recv {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_block_recv\\\";\\n\\n  call hlx_deny;\\n  call hlx_allow;\\n}\\n\\n# Gets the content owner for the current strain and sets the X-Owner header\\nsub hlx_owner {\\n  call hlx_owner_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_owner\\\";\\n\\n  set req.http.X-Owner = table.lookup(strain_owners, req.http.X-Strain);\\n  if (!req.http.X-Owner) {\\n    set req.http.X-Owner = table.lookup(strain_owners, \\\"default\\\");\\n  }\\n\\n  call hlx_owner_after;\\n}\\n\\n# Gets the directory index for the current strain\\nsub hlx_index {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_index\\\";\\n\\n  set req.http.X-Index = table.lookup(strain_index_files, req.http.X-Strain);\\n  if (!req.http.X-Index) {\\n    set req.http.X-Index = table.lookup(strain_index_files, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the content repo\\nsub hlx_repo {\\n  call hlx_repo_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_repo\\\";\\n  set req.http.X-Repo = table.lookup(strain_repos, req.http.X-Strain);\\n  if (!req.http.X-Repo) {\\n    set req.http.X-Repo = table.lookup(strain_repos, \\\"default\\\");\\n  }\\n\\n  call hlx_repo_after;\\n}\\n\\n# Gets the content ref\\nsub hlx_ref {\\n  call hlx_ref_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_ref\\\";\\n  set req.http.X-Ref = table.lookup(strain_refs, req.http.X-Strain);\\n  # fall back to default strain\\n  if (!req.http.X-Ref) {\\n    set req.http.X-Ref = table.lookup(strain_refs, \\\"default\\\");\\n  }\\n  # if default isn't set, use 'master'\\n  if (!req.http.X-Ref) {\\n    set req.http.X-Ref = \\\"master\\\";\\n  }\\n\\n  call hlx_ref_after;\\n}\\n\\n# Gets the content path root\\nsub hlx_root_path {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_root_path\\\";\\n  set req.http.X-Repo-Root-Path = table.lookup(strain_root_paths, req.http.X-Strain);\\n  if (!req.http.X-Repo-Root-Path) {\\n    set req.http.X-Repo-Root-Path = table.lookup(strain_root_paths, \\\"default\\\");\\n  }\\n  if (!req.http.X-Repo-Root-Path) {\\n    set req.http.X-Repo-Root-Path = \\\"\\\";\\n  }\\n}\\n\\nsub hlx_action_root {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_action_root\\\";\\n  set req.http.X-Action-Root = table.lookup(strain_action_roots, req.http.X-Strain);\\n  if (!req.http.X-Action-Root) {\\n    set req.http.X-Action-Root = table.lookup(strain_action_roots, \\\"default\\\");\\n  }\\n  #set req.http.X-Action-Root = \\\"/trieloff/default/git-github-com-adobe-helix-cli-git--dirty--\\\";\\n}\\n\\n# Gets the github static repo\\nsub hlx_github_static_repo {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_repo\\\";\\n  set req.http.X-Github-Static-Repo = table.lookup(strain_github_static_repos, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Repo) {\\n    set req.http.X-Github-Static-Repo = table.lookup(strain_github_static_repos, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the github static owner\\nsub hlx_github_static_owner {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_owner\\\";\\n  set req.http.X-Github-Static-Owner = table.lookup(strain_github_static_owners, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Owner) {\\n    set req.http.X-Github-Static-Owner = table.lookup(strain_github_static_owners, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the github static root\\nsub hlx_github_static_root {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_root\\\";\\n  set req.http.X-Github-Static-Root = table.lookup(strain_github_static_root, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Root) {\\n    set req.http.X-Github-Static-Root = table.lookup(strain_github_static_root, \\\"default\\\");\\n  }\\n  if (!req.http.X-Github-Static-Root) {\\n    set req.http.X-Github-Static-Root = \\\"/\\\";\\n  }\\n  set req.http.X-Trace = req.http.X-Trace + \\\"(\\\" + req.http.X-Github-Static-Root +  \\\")\\\";\\n}\\n\\n# Gets the github static ref\\nsub hlx_github_static_ref {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_ref\\\";\\n  set req.http.X-Github-Static-Ref = table.lookup(strain_github_static_refs, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Ref) {\\n    set req.http.X-Github-Static-Ref = table.lookup(strain_github_static_refs, \\\"default\\\");\\n  }\\n}\\n\\n# rewrite required headers (called from fetch)\\nsub hlx_headers_fetch {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_headers_fetch\\\";\\n\\n  # Add Surrogate-Key headers for soft purges\\n  if (!beresp.http.Surrogate-Key) {\\n    set beresp.http.Surrogate-Key = \\\"all\\\";\\n  } else{\\n    set beresp.http.Surrogate-Key = \\\"all \\\" + beresp.http.Surrogate-Key;\\n  }\\n\\n  # Only do this when X-Debug is present, since `Vary: X-Debug` will cause\\n  # misses, making it useless to keep this on regular objects.\\n  if (req.http.X-Debug) {\\n    if (!beresp.http.X-Backend-Name) {\\n      set beresp.http.X-Backend-Name = beresp.backend.name;\\n    }\\n    if (!beresp.http.X-CDN-Request-ID) {\\n      set beresp.http.X-CDN-Request-ID = req.http.X-CDN-Request-ID;\\n    }\\n  }\\n}\\n\\nsub hlx_headers_deliver {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_headers_deliver\\\";\\n\\n  # Set HSTS since we always do HTTPS\\n  set resp.http.Strict-Transport-Security = \\\"max-age=31536000\\\";\\n\\n  set resp.http.X-Version = req.http.X-Version;\\n\\n  if( req.http.X-Debug ) {\\n    set resp.http.X-URL = req.url;\\n    set resp.http.X-Orig-Url = req.http.X-Orig-Url;\\n    set resp.http.X-Backend-URL = req.http.X-Backend-URL;\\n    set resp.http.X-Request-Type = req.http.X-Request-Type;\\n    set resp.http.X-Strain = req.http.X-Strain;\\n    set resp.http.X-Github-Static-Ref = \\\"@\\\" + req.http.X-Github-Static-Ref;\\n\\n    set resp.http.X-Dirname = req.http.X-Dirname;\\n    set resp.http.X-FullDirname = req.http.X-FullDirname;\\n    set resp.http.X-Index = req.http.X-Index;\\n    set resp.http.X-Action-Root = req.http.X-Action-Root;\\n    set resp.http.X-Orig-URL = req.http.X-Orig-URL;\\n    set resp.http.X-Repo-Root-Path = req.http.X-Repo-Root-Path;\\n\\n    set resp.http.X-Fastly-Imageopto-Api = req.http.X-Fastly-Imageopto-Api;\\n\\n    set resp.http.X-Embed = req.http.X-Embed;\\n\\n    set resp.http.X-Trace = req.http.X-Trace;\\n }\\n\\n  call hlx_deliver_errors;\\n}\\n\\nsub hlx_determine_request_type {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_determine_request_type\\\";\\n  // TODO check for topurl\\n  if (req.url.ext == \\\"url\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(static-url)\\\";\\n    set req.http.X-Request-Type = \\\"Static-URL\\\";\\n    return;\\n  }\\n\\n  // TODO check for topurl\\n  if (req.url.ext == \\\"302\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(static-302)\\\";\\n    set req.http.X-Request-Type = \\\"Static-302\\\";\\n    return;\\n  }\\n\\n  # Exit if we already have a type\\n  if (req.http.X-Request-Type) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(existing:\\\" + req.http.X-Request-Type + \\\")\\\" ;\\n    return;\\n  }\\n\\n  // something like https://hlx.blob.core.windows.net/external/098af326aa856bb42ce9a21240cf73d6f64b0b45\\n  if (req.url ~ \\\"^(hlx_([0-9a-f]){40}).(jpg|jpeg|png|webp|gif)$\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(blob)\\\";\\n    set req.http.X-Request-Type = \\\"Blob\\\";\\n    unset req.http.Accept-Encoding;\\n    return;\\n  }\\n\\n  if (req.url.ext ~ \\\"^(hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n    set req.http.X-Request-Type = \\\"Static\\\";\\n    unset req.http.Accept-Encoding;\\n    return;\\n  }\\n\\n  if (req.http.host == \\\"adobeioruntime.net\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(embed)\\\";\\n    set req.http.X-Request-Type = \\\"Embed\\\";\\n    return;\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"(none)\\\";\\n}\\n\\n/**\\n * This subroutine implements static resource prefetching by calling Adobe I/O Runtime\\n * @header X-GitHub-Static-Owner  the owner or organization of the repo that contains the source files\\n * @header X-GitHub-Static-Repo   the repository name of the repo containing the static files\\n * @header X-GitHub-Static-Ref    the branch or tag (or commit) name to serve source files from\\n * @header X-Orig-URL             the original (unmodified) URL, starting after hostname and port\\n */\\nsub hlx_type_static_url {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_static_url\\\";\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.path STRING; # resource path\\n\\n  # Load important information from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n  # TODO: check for URL ending with `/` and look up index file\\n  set var.path = regsub(req.http.X-Orig-URL, \\\".(url|302)$\\\", \\\"\\\");\\n\\n  set req.http.X-Action-Root = \\\"/api/v1/web/\\\" + table.lookup(secrets, \\\"OPENWHISK_NAMESPACE\\\") + \\\"/helix-services/static@v1\\\";\\n  set req.http.X-Backend-URL = req.http.X-Action-Root\\n    + \\\"?owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026path=\\\" + var.path\\n    # TODO: load magic flag\\n    + \\\"\\u0026plain=true\\\"\\n    + \\\"\\u0026allow=\\\" urlencode(req.http.X-Allow)\\n    + \\\"\\u0026deny=\\\" urlencode(req.http.X-Deny)\\n    + \\\"\\u0026root=\\\" + req.http.X-Github-Static-Root;\\n}\\n\\n/**\\n * This subroutine implements static file handling by calling\\n * the hlx--static action in OpenWhisk\\n * @header X-GitHub-Static-Owner  the owner or organization of the repo that contains the source files\\n * @header X-GitHub-Static-Repo   the repository name of the repo containing the static files\\n * @header X-GitHub-Static-Ref    the branch or tag (or commit) name to serve source files from\\n * @header X-Orig-URL             the original (unmodified) URL, starting after hostname and port\\n */\\nsub hlx_type_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_static\\\";\\n  # This is a static request.\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.path STRING; # resource path\\n  declare local var.esi STRING;\\n\\n  # Load important information from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n\\n  # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441\\n  if (req.url ~ \\\"^(.*)(.hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n    # and keep only the non-hashed part, i.e. everything before .hlx_\\n    set var.path = re.group.1;\\n    set var.esi = \\\"\\u0026esi=true\\\";\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(normal)\\\";\\n    # TODO: check for URL ending with `/` and look up index file\\n    set var.path = req.url;\\n    set var.esi = \\\"\\\";\\n  }\\n  set var.path = regsuball(var.path, \\\"/+\\\", \\\"/\\\");\\n\\n  set req.http.X-Action-Root = \\\"/api/v1/web/\\\" + table.lookup(secrets, \\\"OPENWHISK_NAMESPACE\\\") + \\\"/helix-services/static@v1\\\";\\n  set req.http.X-Backend-URL = req.http.X-Action-Root\\n    + \\\"?owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026path=\\\" + var.path\\n    + var.esi\\n    # TODO: load magic flag\\n    + \\\"\\u0026plain=true\\\"\\n    + \\\"\\u0026allow=\\\" urlencode(req.http.X-Allow)\\n    + \\\"\\u0026deny=\\\" urlencode(req.http.X-Deny)\\n    + \\\"\\u0026root=\\\" + req.http.X-Github-Static-Root;\\n}\\n\\nsub hlx_type_blob {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_blob\\\";\\n  # This is a blob request.\\n\\n  # get it from Azure Blob Storage\\n  set req.backend = F_AzureBlobs;\\n\\n  declare local var.sha STRING;\\n  declare local var.ext STRING;\\n\\n  if (req.url ~ \\\"^hlx_(([0-9a-f]){40}).(jpg|jpeg|png|webp|gif)$\\\") {\\n    set var.sha = re.group.1;\\n    set var.ext = req.url.ext;\\n\\n    # TODO verify\\n    set req.http.X-Fastly-Imageopto-Api = \\\"fastly\\\";\\n  }\\n\\n  set req.http.X-Backend-URL = \\\"/external/\\\" + var.sha;\\n}\\n\\n\\n/**\\n * Handle redirect-serving for static files\\n * If the static file is too large for the hlx--static action to serve,\\n * because the payload would exceed 1 MB (OpenWhisk limit), the request\\n * is restarted, using the `X-Request-Type: Redirect` header, which means the\\n * static content will be fetched directly from GitHub, and the required\\n * response headers like Content-Type will be injected later on.\\n */\\nsub hlx_type_redirect {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_redirect\\\";\\n  # Handle a redirect from static.js by\\n  # - fetching the resource from GitHub\\n  # - don't forget to override the Content-Type header\\n  set req.backend = F_GitHub;\\n  # Replace what we have in the cache already (which is the cached redirect)\\n  set req.hash_always_miss = true;\\n}\\n\\nsub hlx_fetch_blob {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_blob\\\";\\n  if (req.http.X-Request-Type == \\\"Blob\\\" \\u0026\\u0026 beresp.status == 200) {\\n    # The URLs are a hash of the content, so we can cache stuff for a year\\n    # both on the edge and in the browser\\n    set beresp.http.Cache-Control = \\\"max-age=31622400,immutable\\\";\\n    set beresp.http.Surrogate-Control = \\\"max-age=31622400,immutable\\\";\\n    set beresp.cacheable = true;\\n    set beresp.ttl = 31622400s;\\n\\n    # TODO: should we set req.http.X-Fastly-Imageopto-Api ?\\n\\n    return(deliver);\\n  }\\n}\\n\\nsub hlx_fetch_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_static\\\";\\n  declare local var.ext STRING;\\n\\n  if (req.http.X-Request-Type == \\\"Static-URL\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(url)\\\";\\n    # Get the ETag response header and use it to construct a stable URL\\n\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n    set req.http.X-Trace = req.http.X-Trace + \\\"[url=\\\" + req.http.X-Orig-URL + \\\", ext=\\\" + var.ext + \\\"]\\\";\\n    set req.http.X-Location = regsub(req.http.X-Orig-URL, \\\".url$\\\", var.ext);\\n    error 303 \\\"URL\\\";\\n  }\\n  if (req.http.X-Request-Type == \\\"Static-302\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(302)\\\";\\n    # Get the ETag response header and use it to construct a stable URL\\n\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n    set req.http.X-Trace = req.http.X-Trace + \\\"[url=\\\" + req.http.X-Orig-URL + \\\", ext=\\\" + var.ext + \\\"]\\\";\\n    set req.http.X-Location = regsub(req.http.X-Orig-URL, \\\".302$\\\", var.ext);\\n    error 902 \\\"302\\\";\\n  }\\n  # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441\\n  if (req.http.X-Orig-URL ~ \\\"^(.*)(.hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n\\n    if (re.group.2 == var.ext) {\\n      set req.esi = true;\\n      esi;\\n      set beresp.http.X-ESI = \\\"processed(\\\" + bereq.http.Accept-Encoding + \\\", \\\" + req.esi + \\\",\\\" + req.http.X-From-Edge +\\\")\\\";\\n      set beresp.http.x-compress-hint = \\\"on\\\"; // so h2o compresses it on the way out\\n      set beresp.http.Cache-Control = \\\"max-age=31622400,immutable\\\"; # keep it for a year in the browser;\\n      set beresp.http.Surrogate-Control = \\\"max-age=31622400,immutable\\\";\\n      set beresp.cacheable = true;\\n      set beresp.ttl = 31622400s;\\n    } else {\\n      set beresp.ttl = 300s;\\n      error 404 \\\"Invalid\\\";\\n      set beresp.http.X-Trace = \\\"etag=\\\" + beresp.http.ETag + \\\"; ext=\\\" + var.ext;\\n\\n    }\\n    return(deliver);\\n  }\\n  if (beresp.http.X-Static == \\\"Raw/Static\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(raw)\\\";\\n    if (beresp.status == 307) {\\n      # Keep the redirect around for a short bit, to prevent thundering herd\\n      set beresp.cacheable = true;\\n      set beresp.ttl = 5s;\\n    }\\n    return(deliver);\\n  } elsif (req.http.X-Request-Type == \\\"Redirect\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(redirect)\\\";\\n    // and this is where we fix the headers of the GitHub static response\\n    // so that they become digestible by a browser.\\n    // - recover Content-Type from X-Content-Type\\n    // - filter out GitHub-headers\\n\\n    set beresp.http.Content-Type = req.http.X-Static-Content-Type;\\n    unset beresp.http.X-Content-Type-Options;\\n    unset beresp.http.X-Frame-Options;\\n    unset beresp.http.X-XSS-Protection;\\n    unset beresp.http.Content-Security-Policy;\\n  } elsif (beresp.status == 404 || beresp.status == 204) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(400)\\\";\\n    # Cache for a short time, restart will get rid of it anyway\\n    set beresp.ttl = 60s;\\n    return(deliver);\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(none)\\\";\\n  }\\n}\\n\\n/**\\n * Fallback handling. Depending on the previous step and the previous status code, either\\n * deliver or restart.\\n */\\nsub hlx_deliver_type {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_type(\\\" + req.http.X-Request-Type + \\\")\\\";\\n  if (req.http.X-Request-Type == \\\"Dispatch\\\") {\\n    call hlx_deliver_static;\\n  }\\n}\\n\\n/**\\n * Handle the delivery of error handlers. There are two scenarios here:\\n * 1. either the error page could be delivered from dispatch, then do nothing\\n * 2. no error page could be found, so set the correct status code and deliver a fallback\\n */\\nsub hlx_fetch_error {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_error(\\\" + beresp.status + \\\")\\\";\\n  # only use syntethic errors if not in esi sub-request and no content is delivered from the dispatcher.\\n  if (!req.http.x-topurl \\u0026\\u0026 beresp.status != 200 \\u0026\\u0026 beresp.http.Content-Length == \\\"0\\\") {\\n    # TODO: fix headers\\n    if (beresp.status == 404) {\\n       error 951 \\\"Not Found\\\";\\n    } else {\\n       error 952 \\\"Internal Server Error\\\";\\n    }\\n  }\\n  # if (req.url.basename ~ \\\"^([0-9][0-9][0-9])\\\") {\\n  #   set beresp.status = std.atoi(re.group.1);\\n  # } else {\\n  #   # this should never happen\\n  #   set beresp.status = 500;\\n  # }\\n}\\n\\n/**\\n * Handle delivery of static stuff. If there is a 404, restart with error\\n * if there is content, just deliver it. If there is a redirect, fetch\\n * from redirect and adjust headers\\n */\\nsub hlx_deliver_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_static\\\";\\n  if (resp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(ok)\\\";\\n    return;\\n  } elsif (resp.status == 307) {\\n    # perform some additional validation\\n    if (resp.http.Location ~ \\\"https://raw.githubusercontent.com(/.*)\\\") {\\n      set req.http.X-Request-Type = \\\"Redirect\\\";\\n      set req.http.X-Backend-URL = re.group.1;\\n      set req.http.X-Static-Content-Type = resp.http.X-Content-Type;\\n      set req.http.X-Trace = req.http.X-Trace + \\\"(redirect)\\\";\\n      restart;\\n    } else {\\n      set resp.status = 500;\\n      set resp.response = \\\"Redirect to wrong hostname\\\";\\n      set req.http.X-Trace = req.http.X-Trace + \\\"(redirect-error)\\\";\\n    }\\n  } else {\\n    # any other error, ignore\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(error)\\\";\\n    #set req.http.X-Request-Type = \\\"Error\\\";\\n    #set req.url = \\\"/\\\" + resp.status + \\\".html\\\"; // fall back to 500.html\\n    #restart;\\n  }\\n}\\n\\n/**\\n * Handle requests to Adobe I/O Runtime services.\\n * When Fastly handles ESI requests to 3rd-party domains, they still get routed\\n * through this service. In this method we make sure that ESI requests destined\\n * for Adobe I/O Runtime, e.g. the helix-embed service are passed through to\\n * the correct backend.\\n */\\nsub hlx_type_embed {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_embed\\\";\\n  # This is an embed request\\n  # Fastly sends embed requests back to the same service config (which is why\\n  # we are handling it here), but keeps the correct Host header in place (which\\n  # is why we can check against it)\\n  set req.backend = F_AdobeRuntime;\\n}\\n\\n\\n/**\\n * Handles requests for the main Helix rendering pipeline.\\n */\\nsub hlx_type_dispatch {\\n  call hlx_type_pipeline_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_dispatch\\\";\\n  # This is a dynamic request.\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.action STRING; # the action to call\\n  declare local var.namespace STRING;\\n  declare local var.package STRING;\\n\\n  # Load important information for content repo from edge dicts\\n  call hlx_owner;\\n  call hlx_repo;\\n  call hlx_ref;\\n  call hlx_root_path;\\n  call hlx_index;\\n\\n  # Load important information for fallback repo from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n\\n  # enable ESI\\n  # TODO: move to dispatch action\\n  set req.http.x-esi = \\\"1\\\";\\n\\n\\n  # sets X-Action-Root to something like trieloff/b7aa8a6351215b7e12b6d3be242c622410c1eb28\\n  call hlx_action_root;\\n  set var.namespace = regsuball(req.http.X-Action-Root, \\\"/.*$\\\", \\\"\\\"); // cut away the slash and everything after it\\n  set var.package = regsuball(req.http.X-Action-Root, \\\"^.*/\\\", \\\"\\\"); // cut away everything from the start up to (including) the slash\\n\\n\\n  # get (strain-specific) parameter whitelist\\n  include \\\"params.vcl\\\";\\n\\n  set req.http.X-Backend-URL = \\\"/api/v1/web\\\"\\n    + \\\"/\\\" + var.namespace // i.e. /trieloff\\n    + \\\"/helix-services/dispatch@\\\" + req.http.X-Dispatch-Version\\n    // fallback repo\\n    + \\\"?static.owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026static.repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026static.ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026static.root=\\\" + req.http.X-Github-Static-Root\\n    // content repo\\n    + \\\"\\u0026content.owner=\\\" + req.http.X-Owner\\n    + \\\"\\u0026content.repo=\\\" + req.http.X-Repo\\n    + \\\"\\u0026content.ref=\\\" + req.http.X-Ref\\n    + \\\"\\u0026content.root=\\\" + req.http.X-Repo-Root-Path\\n    + \\\"\\u0026content.package=\\\" + var.package\\n    + \\\"\\u0026content.index=\\\" + req.http.X-Index\\n    + \\\"\\u0026path=\\\" + req.url.path\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026rootPath=\\\" + req.http.X-Root-Path;\\n\\n  # only append the encoded params if there are encoded params\\n  if (req.http.X-Encoded-Params) {\\n    set req.http.X-Backend-URL = req.http.X-Backend-URL\\n      + \\\"\\u0026params=\\\" + req.http.X-Encoded-Params;\\n  }\\n\\n  call hlx_type_pipeline_after;\\n}\\n\\n/**\\n * Handle requests to Proxy Strains.\\n * These requests already have a backend set as part of the strain resolution\\n * so there is no need for URL rewriting.\\n */\\nsub hlx_type_proxy {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_proxy\\\";\\n  # TODO: set Forwarded header? (RFC7239)\\n  # TODO: Host header/URL rewrites? or all done at strain resolution time?\\n\\n  # Pass here so that `dynamic.vcl` doesn't execute for Proxy requests\\n  # And we do a pass, not a lookup, because caching third parties is way too\\n  # risky, and would take a lot of work in `vcl_fetch` to get right.\\n  return(pass);\\n}\\n\\n/**\\n  This checks X-Debug key\\n*/\\nsub hlx_check_debug_key {\\n  declare local var.debugSecret STRING;\\n  declare local var.key STRING;\\n  declare local var.level STRING;\\n\\n  set var.debugSecret = table.lookup(secrets, \\\"DEBUG_KEY\\\");\\n  set var.key = regsub(req.http.X-Debug, \\\":.*$\\\", \\\"\\\");\\n\\n  if (req.http.X-Debug ~ \\\":\\\") {\\n    set var.level = regsub(req.http.X-Debug, \\\"^.*:\\\", \\\"\\\");\\n  } else {\\n    set var.level = \\\"debug\\\";\\n  }\\n\\n  //X-Debug must be protected\\n  if (var.debugSecret \\u0026\\u0026 var.key == var.debugSecret) {\\n    set req.http.X-Debug = var.level;\\n  } else {\\n    unset req.http.X-Debug;\\n  }\\n}\\n\\n/**\\n * This is where all requests are received.\\n */\\nsub vcl_recv {\\n  if (req.restarts == 0) {\\n    if (req.http.X-Trace) {\\n      set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_recv\\\";\\n    } else {\\n      set req.http.X-Trace = \\\"vcl_recv\\\";\\n    }\\n  } else {\\n    # So we don't have to add `RESTART` to `X-Trace` whenever we use `restart`\\n    set req.http.X-Trace = req.http.X-Trace + \\\"; RESTART; vcl_recv\\\";\\n  }\\n\\n  call hlx_check_debug_key;\\n  call hlx_recv_init;\\n\\n  # run generated vcl\\n  include \\\"dynamic.vcl\\\";\\n\\n#FASTLY recv\\n\\n  # X-Location gets set by Helix's redirect logic inside the FASTLY recv block\\n  # that will get injected above.\\n  if (req.http.X-Location) {\\n    error 301 \\\"Redirect\\\";\\n  }\\n\\n  # TODO: Do we even want to set a regular origin as default? Possibly set one\\n  # that acts as a canary. If requests reach it, the VCL isn't setting a backend\\n  # somewhere.\\n  set req.backend = F_AdobeRuntime;\\n\\n  if (req.http.X-From-Edge) {\\n    # Request came from a Fastly POP, send the raw response without ESI processing\\n    set req.esi = false;\\n  } elseif ( req.url.ext == \\\"html\\\" ) {\\n    set req.http.x-esi = \\\"1\\\";\\n  }\\n\\n  # somehow we don't see the req.topurl in vcl_fetch, so we remember it here\\n  if (req.topurl) {\\n    set req.http.x-topurl = req.topurl;\\n  }\\n\\n  // compute X-FullDirname which contains the real incoming path of directories\\n  if (req.url.ext == \\\"\\\") {\\n    // case url = /a/b -\\u003e for Fastly, dirname = /a and basename = b\\n    set req.http.X-FullDirname = req.url.dirname + \\\"/\\\" + req.url.basename;\\n  } else {\\n    // case url = /a/b/c.html -\\u003e for Fastly, dirname = /a/b which is what we need\\n    set req.http.X-FullDirname = req.url.dirname;\\n  }\\n  // remove potential double slashes\\n  set req.http.X-FullDirname = regsuball(req.http.X-FullDirname, \\\"/+\\\", \\\"/\\\");\\n\\n  # Determine the current strain and execute strain-specific code\\n  call hlx_strain;\\n\\n  # block bad requests – needs current strain and unchanged req.url\\n  call hlx_block_recv;\\n\\n  # Must be after `hlx_strain`, because that might set `Proxy` as type\\n  call hlx_determine_request_type;\\n\\n  # Force clustering (despite the name of the header) to make sure we get good\\n  # cache efficiency with restarts. Without this, Fastly clustering would be\\n  # disabled after a restart, which means that each node in a Fastly POP would\\n  # use its own cache, instead of checking the designated node for the object.\\n  set req.http.Fastly-Force-Shield = \\\"yes\\\";\\n\\n  if (req.http.X-Request-Type == \\\"Proxy\\\") {\\n    call hlx_type_proxy;\\n  } elsif (req.http.X-Request-Type == \\\"Static\\\") {\\n    call hlx_type_static;\\n  } elsif (req.http.X-Request-Type == \\\"Blob\\\") {\\n    call hlx_type_blob;\\n  } elsif (req.http.X-Request-Type == \\\"Redirect\\\") {\\n    call hlx_type_redirect;\\n  } elsif (req.http.X-Request-Type == \\\"Embed\\\") {\\n    call hlx_type_embed;\\n  } elseif (req.http.X-Request-Type == \\\"Static-URL\\\") {\\n    call hlx_type_static_url;\\n  } elseif (req.http.X-Request-Type == \\\"Static-302\\\") {\\n    call hlx_type_static_url;\\n  } else {\\n    set req.http.X-Request-Type = \\\"Dispatch\\\";\\n    call hlx_type_dispatch;\\n  }\\n\\n  # re-enable shielding for changed backends\\n  # include \\\"reset.vcl\\\";\\n\\n  # We only handle GET and HEAD requests, but Proxy strains might\\n  if (req.request != \\\"HEAD\\\" \\u0026\\u0026 req.request != \\\"GET\\\" \\u0026\\u0026 req.request != \\\"FASTLYPURGE\\\") {\\n    error 405;\\n  }\\n\\n  return(lookup);\\n}\\n\\nsub hlx_fetch_errors {\\n  if (req.http.x-topurl) {\\n    # don't set syntethic error for ESI sub-requests\\n    return;\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_errors\\\";\\n  # Interpreting OpenWhisk errors is a bit tricky, because we don't have access to the JSON\\n  # of the response body. Instead we are using the Content-Length of known error messages\\n  # to determine the most likely root cause. Each root cause will get an internal status code\\n  # starting with 951, which is then handled by `hlx_error_errors` and `hlx_deliver_errors`\\n  if ( beresp.status == 404 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"74\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 951 \\\"Unknown Extension\\\";\\n  }\\n\\n  if ( beresp.status == 404 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"69\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 952 \\\"Wrong Code Path\\\";\\n  }\\n\\n  if ( beresp.status == 401 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"65\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 953 \\\"Can't Call Action\\\";\\n  }\\n}\\n\\nsub hlx_deliver_errors {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_errors\\\";\\n\\n  # Cache Condition: OpenWhisk Error Prio: 10\\n  if (resp.status == 951 ) {\\n     set resp.status = 404;\\n     set resp.response = \\\"Not Found\\\";\\n  }\\n  if (resp.status == 952 ) {\\n     set resp.status = 500;\\n     set resp.response = \\\"Internal Server Error\\\";\\n  }\\n  if (resp.status == 953 ) {\\n     set resp.status = 500;\\n     set resp.response = \\\"Internal Server Error\\\";\\n  }\\n  if (resp.status == 954) {\\n    if (req.url.basename ~ \\\"^([0-9][0-9][0-9])\\\") {\\n      set resp.status = std.atoi(re.group.1);\\n    } else {\\n      # this should never happen\\n      set resp.status = 500;\\n    }\\n  }\\n}\\n\\nsub hlx_error_errors {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_error_errors\\\";\\n  # Cache Condition: OpenWhisk Error Prio: 10\\n  if (obj.status == 951 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eResource not Found\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n\\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n\\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n\\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n\\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n\\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n\\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite;\\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6;\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e404\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eRESOURCE\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eNOT FOUND\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThe requested resource could not be found..\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\n\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 952 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n\\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n\\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n\\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n\\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n\\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n\\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite;\\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6;\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThere was an error processing your request.\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\n\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 953 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThe configured backend authentication has been rejected.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 954) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    if (req.url.basename ~ \\\"^404\\\") {\\n      synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eResource not found\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n          \\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n            \\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n            \\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n            \\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n            \\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n            \\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite; \\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6; \\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8; \\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8; \\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }    \\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e404\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eRESOURCE\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eNOT FOUND\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThe requested resource could not be found.\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\\"};\\n      return(deliver);\\n    }\\n    if (req.url.basename ~ \\\"^500\\\") {\\n      synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThere was an error processing your request.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n      return(deliver);\\n    }\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThere was an unknown error processing your request.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n    return(deliver);\\n  }\\n}\\n\\nsub vcl_fetch {\\n  # store trace information in backend response headers in order\\n  # to make them available in vcl_deliver\\n  set beresp.http.X-Trace = req.http.X-Trace;\\n  set beresp.http.X-PreFetch-Pass = req.http.X-PreFetch-Pass;\\n  set beresp.http.X-PreFetch-Miss = req.http.X-PreFetch-Miss;\\n  set beresp.http.X-PostFetch = \\\"; vcl_fetch(\\\" beresp.status \\\": \\\" req.url \\\" \\\" req.http.X-Request-Type \\\")\\\";\\n#FASTLY fetch\\n\\n  # Sprinkling in our debugging\\n  call hlx_headers_fetch;\\n\\n  # Don't try to do anything else with Proxy requests\\n  if (req.http.X-Request-Type == \\\"Proxy\\\") {\\n    return(pass);\\n  }\\n\\n  call hlx_fetch_errors;\\n\\n  unset beresp.http.Set-Cookie;\\n  unset beresp.http.Vary;\\n  unset beresp.http.Expires;\\n\\n  # We Vary on X-Debug, so that it's automatically a cache-miss, and we go to\\n  # origin. Origin will raise the log level for such requests too. So all roung\\n  # convenience.\\n  if (beresp.http.Vary !~ \\\"X-Debug\\\") {\\n    if (beresp.http.Vary) {\\n      set beresp.http.Vary = beresp.http.Vary + \\\",X-Debug\\\";\\n    } else {\\n      set beresp.http.Vary = \\\"X-Debug\\\";\\n    }\\n  }\\n  # Vary on Strain for pipeline and static, since we're sending strain in the\\n  # backend URL.\\n  if (beresp.http.Vary !~ \\\"X-Strain\\\") {\\n    # Vary is already set above\\n    set beresp.http.Vary = beresp.http.Vary + \\\",X-Strain\\\";\\n  }\\n\\n  # Vary on Request-Type, so that static requests don't interfere with\\n  # dynamic requests: https://github.com/adobe/helix-publish/issues/45\\n  if (beresp.http.Vary !~ \\\"X-Request-Type\\\") {\\n    set beresp.http.Vary = beresp.http.Vary + \\\",X-Request-Type\\\";\\n  }\\n\\n  # TODO: Add Surrogate-Keys, based on req.url/X-Orig-URL\\n\\n  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ \\\"max-age\\\" || beresp.http.Cache-Control ~ \\\"(s-maxage|max-age)\\\") {\\n    # Use TTL from origin\\n  } else {\\n    # apply a default ttl\\n    if (beresp.status == 200) {\\n      set beresp.ttl = 604800s;\\n      set beresp.http.Cache-Control = \\\"max-age=604800, public\\\";\\n    } else {\\n      set beresp.ttl = 60s;\\n    }\\n  }\\n\\n  # checks if the request is a redirect or .hlx_xxxx request and then call helix-static respectively.\\n  call hlx_fetch_static;\\n\\n  # checks if the request is an Azure Blob\\n  call hlx_fetch_blob;\\n\\n  # check if an error response has an empty body, in this case, the dispatcher didn't deliver\\n  # a valid error page and we use the synthentic one.\\n  # todo: this logic needs to be improved. maybe with a specific response header from the action\\n  call hlx_fetch_error;\\n\\n  if (beresp.http.X-ESI == \\\"enabled\\\" || req.http.x-esi) {\\n    esi;\\n  }\\n\\n  return(deliver);\\n}\\n\\nsub vcl_hash {\\n  set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hash(\\\" req.http.host req.url \\\")\\\";\\n#FASTLY hash\\n}\\n\\nsub vcl_hit {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_hit(\\\" req.url \\\")\\\";\\n#FASTLY hit\\n\\n  if (!obj.cacheable) {\\n    return(pass);\\n  }\\n  return(deliver);\\n}\\n\\n/**\\n * Do all BackEnd REQuest changes. One sub to be called from both vcl_miss and\\n * vcl_pass, to avoid code-rot through having to update two places.\\n */\\nsub hlx_bereq {\\n  if (req.http.X-PreFetch-Miss) {\\n    set req.http.X-PreFetch-Miss = req.http.X-PreFetch-Miss + \\\"; hlx_bereq\\\";\\n  } elseif (req.http.X-PreFetch-Pass) {\\n    set req.http.X-PreFetch-Pass = req.http.X-PreFetch-Pass + \\\"; hlx_bereq\\\";\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_bereq\\\";\\n  }\\n\\n  # If we're going to a shield (another Fastly POP) use the original URL and\\n  # Host header. If not a shield, we're going to origin; set the URL and Host\\n  # header as explained at the top of this file.\\n  if (req.backend.is_shield) {\\n    set bereq.url = req.http.X-Orig-Url;\\n    set bereq.http.Host = req.http.X-Orig-Host;\\n  } else {\\n    if (req.http.X-Backend-URL) {\\n      set bereq.url = req.http.X-Backend-URL;\\n    }\\n    if (req.backend == F_AdobeRuntime) {\\n      set bereq.http.Host = \\\"adobeioruntime.net\\\";\\n    } elsif (req.backend == F_GitHub) {\\n      set bereq.http.Host = \\\"raw.githubusercontent.com\\\";\\n    }\\n  }\\n\\n  if (req.backend == F_AdobeRuntime) {\\n    # set Adobe Runtime backend authentication\\n    set bereq.http.Authorization = table.lookup(secrets, \\\"OPENWHISK_AUTH\\\");\\n    # pass Github Token via X-Github-Token header\\n    set bereq.http.X-Github-Token = table.lookup(secrets, \\\"GITHUB_TOKEN\\\");\\n  } elsif (req.backend == F_GitHub \\u0026\\u0026 table.lookup(secrets, \\\"GITHUB_TOKEN\\\")) {\\n    # set Github backend authentication\\n    set bereq.http.Authorization = \\\"token \\\" + table.lookup(secrets, \\\"GITHUB_TOKEN\\\");\\n  }\\n\\n  # making sure to get an uncompressed object for ESI\\n  unset bereq.http.Accept-Encoding;\\n\\n  # Clean up all temporary request headers, since origins might be 3rd parties\\n  unset bereq.http.X-Orig-Url;\\n  unset bereq.http.X-Orig-Host;\\n  unset bereq.http.X-Backend-URL;\\n  unset bereq.http.X-Request-Type;\\n  unset bereq.http.X-Static-Content-Type;\\n  unset bereq.http.X-Allow;\\n  unset bereq.http.X-Deny;\\n  unset bereq.http.X-Owner;\\n  unset bereq.http.X-Index;\\n  unset bereq.http.X-Repo;\\n  unset bereq.http.X-Ref;\\n  unset bereq.http.X-Root-Path;\\n  unset bereq.http.X-Action-Root;\\n  unset bereq.http.X-Github-Static-Repo;\\n  unset bereq.http.X-Github-Static-Owner;\\n  unset bereq.http.X-Github-Static-Root;\\n  unset bereq.http.X-Github-Static-Ref;\\n}\\n\\nsub vcl_miss {\\n  set req.http.X-PreFetch-Miss = \\\"; vcl_miss(\\\" bereq.http.host bereq.url \\\")\\\";\\n#FASTLY miss\\n\\n  call hlx_set_from_edge;\\n\\n  call hlx_bereq;\\n\\n  return(fetch);\\n}\\n\\nsub vcl_pass {\\n  set req.http.X-PreFetch-Pass = \\\"; vcl_pass\\\";\\n#FASTLY pass\\n\\n  call hlx_set_from_edge;\\n\\n  call hlx_bereq;\\n\\n  return(pass);\\n}\\n\\nsub vcl_deliver {\\n  # reconstruct VCL trace from information stored in backend response headers\\n  if (resp.http.X-Trace) {\\n    set req.http.X-Trace = resp.http.X-Trace;\\n  }\\n\\n  if (fastly_info.state ~ \\\"^HITPASS\\\") {\\n    set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hit(object: uncacheable, return: pass)\\\";\\n  } elseif (fastly_info.state ~ \\\"^HIT\\\") {\\n    set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hit(\\\" req.http.host req.url \\\")\\\";\\n  } else {\\n    if (resp.http.X-PreFetch-Pass) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PreFetch-Pass;\\n    }\\n\\n    if (resp.http.X-PreFetch-Miss) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PreFetch-Miss;\\n    }\\n\\n    if (resp.http.X-PostFetch) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PostFetch;\\n    }\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_deliver\\\";\\n#FASTLY deliver\\n\\n  call hlx_headers_deliver;\\n\\n  call hlx_deliver_type;\\n\\n  # only set the strain cookie for sticky strains\\n  # and only do it for the Adobe I/O Runtime backend\\n  # Proxy strains can't be sticky, because resolution sets backend and what not,\\n  # so skipping resolution would skip that too.\\n  if (req.http.X-Strain \\u0026\\u0026 req.http.X-Sticky == \\\"true\\\"\\n      \\u0026\\u0026 req.backend == F_AdobeRuntime \\u0026\\u0026 req.http.X-Request-Type != \\\"Proxy\\\") {\\n    set resp.http.Set-Cookie = \\\"X-Strain=\\\" + req.http.X-Strain + \\\"; Secure; HttpOnly; SameSite=Strict;\\\";\\n  }\\n\\n  # remove temporary headers used to reconstruct trace information\\n  unset resp.http.X-PreFetch-Miss;\\n  unset resp.http.X-PreFetch-Pass;\\n  unset resp.http.X-PostFetch;\\n\\n  if (!req.http.X-Debug) {\\n    # Unless we are debugging, shut up chatty headers\\n    unset resp.http.Access-Control-Allow-Headers;\\n    unset resp.http.Access-Control-Allow-Methods;\\n    unset resp.http.Access-Control-Allow-Origin;\\n    unset resp.http.Perf-Br-Resp-Out;\\n    unset resp.http.Server;\\n    unset resp.http.Server-Timing;\\n    unset resp.http.Via;\\n    unset resp.http.X-Backend-Name;\\n    unset resp.http.X-Backend-URL;\\n    unset resp.http.X-Cache-Hits;\\n    unset resp.http.X-Cache;\\n    unset resp.http.X-CDN-Request-ID;\\n    unset resp.http.X-Content-Type-Options;\\n    unset resp.http.X-Content-Type;\\n    unset resp.http.X-ESI;\\n    unset resp.http.X-Fastly-Request-ID;\\n    unset resp.http.X-Frame-Options;\\n    unset resp.http.X-FullDirname;\\n    unset resp.http.X-Geo-Block-List;\\n    unset resp.http.X-GitHub-Request-Id;\\n    unset resp.http.X-GW-Cache;\\n    unset resp.http.x-openwhisk-activation-id;\\n    unset resp.http.X-Request-Id;\\n    unset resp.http.X-Served-By;\\n    unset resp.http.X-Static;\\n    unset resp.http.X-Sticky;\\n    unset resp.http.X-Strain;\\n    unset resp.http.X-Timer;\\n    unset resp.http.X-Trace;\\n    unset resp.http.X-URL;\\n    unset resp.http.x-xss-protection;\\n  } else {\\n    set resp.http.X-Trace = req.http.X-Trace;\\n  }\\n  return(deliver);\\n}\\n\\nsub vcl_error {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_error\\\";\\n#FASTLY error\\n\\n  if (obj.status == 301 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    set obj.http.Location = req.http.X-Location;\\n    synthetic \\\"Moved permanently \\u003ca href='\\\" + req.http.X-Location+ \\\"'\\u003e\\\" + req.http.X-Location + \\\"\\u003c/a\\u003e\\\";\\n    return(deliver);\\n  }\\n  # synthetic response for Static-URL: creates a plain text response with the immutable URL\\n  if (obj.status == 303 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/plain\\\";\\n    set obj.status = 200;\\n    synthetic req.http.X-Location;\\n    return(deliver);\\n  }\\n  # synthetic response for Static-302: creates a redirect to the immutable URL\\n  if (obj.status == 902 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    set obj.status = 302;\\n    set obj.http.Location = req.http.X-Location;\\n    synthetic \\\"Found: \\u003ca href='\\\" + req.http.X-Location+ \\\"'\\u003e\\\" + req.http.X-Location + \\\"\\u003c/a\\u003e\\\";\\n    return(deliver);\\n  }\\n  call hlx_error_errors;\\n}\\n\\nsub vcl_log {\\n#FASTLY log\\n}\\n\",\"version\":247,\"name\":\"helix.vcl\",\"updated_at\":\"2020-01-13T17:02:47Z\",\"created_at\":\"2018-07-19T16:00:41Z\",\"deleted_at\":null,\"main\":true}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "983"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "102510"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:47 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4081-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.458783,VS0,VE1805"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 504,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.294Z",
-        "time": 2063,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 2063
-        }
-      },
-      {
-        "_id": "ab220a92b4c0a7697e99bcf977dd968c",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 64,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 64
-            }
-          ],
-          "headersSize": 212,
-          "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/6tmANh9iLMvWGSoWMt2xIe/items"
-        },
-        "response": {
-          "bodySize": 15,
-          "content": {
-            "mimeType": "application/json",
-            "size": 15,
-            "text": "{\"status\":\"ok\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "979"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "15"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:47 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4058-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.468134,VS0,VE1901"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 2022,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 2022
-        }
-      },
-      {
-        "_id": "809698ff1e04f48cfc4b65bb834c4f92",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 73,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 73
-            }
-          ],
-          "headersSize": 212,
-          "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/6tmoyiJsES3E5YlwmjF8ls/items"
-        },
-        "response": {
-          "bodySize": 15,
-          "content": {
-            "mimeType": "application/json",
-            "size": 15,
-            "text": "{\"status\":\"ok\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "977"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "15"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:46 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4040-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.467607,VS0,VE1273"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 1720,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1720
-        }
-      },
-      {
-        "_id": "79c794055d4d1ef5c21ea82386f89a58",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 69,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 69
-            }
-          ],
-          "headersSize": 212,
-          "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/5JPU8atUUXBuUOXhK5Zctk/items"
-        },
-        "response": {
-          "bodySize": 15,
-          "content": {
-            "mimeType": "application/json",
-            "size": 15,
-            "text": "{\"status\":\"ok\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "976"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "15"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:54 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4036-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.466259,VS0,VE9115"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 9243,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 9243
-        }
-      },
-      {
-        "_id": "6e325a205e6e58c3c23fce8cc3c7c1a0",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 71,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 71
-            }
-          ],
-          "headersSize": 212,
-          "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/1C7mznzU9PHL2isc4Qah6L/items"
-        },
-        "response": {
-          "bodySize": 15,
-          "content": {
-            "mimeType": "application/json",
-            "size": 15,
-            "text": "{\"status\":\"ok\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "982"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "15"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:48 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4082-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.465847,VS0,VE3475"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 3632,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 3632
-        }
-      },
-      {
-        "_id": "3d491a98af21cdb1e776e8a6ea6a34c3",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 74,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 74
-            }
-          ],
-          "headersSize": 212,
-          "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/3ovyFLrfhurRT4VXkjCjaq/items"
-        },
-        "response": {
-          "bodySize": 15,
-          "content": {
-            "mimeType": "application/json",
-            "size": 15,
-            "text": "{\"status\":\"ok\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "972"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "15"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:49 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4052-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.468611,VS0,VE4291"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 4451,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 4451
-        }
-      },
-      {
-        "_id": "1530ba5be5dbd104c47eb031e9094e3a",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 70,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 70
-            }
-          ],
-          "headersSize": 212,
-          "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/6tS8lvtRx0hWi7PATiYTlg/items"
-        },
-        "response": {
-          "bodySize": 15,
-          "content": {
-            "mimeType": "application/json",
-            "size": 15,
-            "text": "{\"status\":\"ok\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "981"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "15"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:50 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4072-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.466988,VS0,VE4943"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 5056,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 5056
-        }
-      },
-      {
-        "_id": "43155cb83343fd49f043888bb36963ca",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 69,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 69
-            }
-          ],
-          "headersSize": 212,
-          "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/6tlvGa6erOOoBYRvJT7hS9/items"
-        },
-        "response": {
-          "bodySize": 15,
-          "content": {
-            "mimeType": "application/json",
-            "size": 15,
-            "text": "{\"status\":\"ok\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "980"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "15"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:51 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4056-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.467529,VS0,VE5599"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 5791,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 5791
-        }
-      },
-      {
-        "_id": "c43c0e659a406fbd63d1fc67d4e3769e",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 64,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 64
-            }
-          ],
-          "headersSize": 212,
-          "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/3Im6QICsW4nWwmJfXOnkOG/items"
-        },
-        "response": {
-          "bodySize": 15,
-          "content": {
-            "mimeType": "application/json",
-            "size": 15,
-            "text": "{\"status\":\"ok\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "975"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "15"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:51 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4030-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.467834,VS0,VE6361"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 6481,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 6481
-        }
-      },
-      {
-        "_id": "7e725ab62f2a04a9da3ad178344b2157",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 70,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 70
-            }
-          ],
-          "headersSize": 212,
-          "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/5Jdxbb1yW7RnHsZU4r5mF6/items"
-        },
-        "response": {
-          "bodySize": 15,
-          "content": {
-            "mimeType": "application/json",
-            "size": 15,
-            "text": "{\"status\":\"ok\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "974"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "15"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:52 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4078-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.471204,VS0,VE7173"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 7296,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 7296
-        }
-      },
-      {
-        "_id": "7b0e206504cfabe88c7aaa9ee5c3f86f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 69,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "host",
-              "value": "api.fastly.com"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 69
-            }
-          ],
-          "headersSize": 212,
-          "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
-          "queryString": [],
-          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/6tmAIs0aCfNXF6zsmtNScQ/items"
-        },
-        "response": {
-          "bodySize": 15,
-          "content": {
-            "mimeType": "application/json",
-            "size": 15,
-            "text": "{\"status\":\"ok\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "status",
-              "value": "200 OK"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "name": "fastly-ratelimit-remaining",
-              "value": "970"
-            },
-            {
-              "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
-            },
-            {
-              "name": "accept-ranges",
-              "value": "bytes, bytes"
-            },
-            {
-              "name": "via",
-              "value": "1.1 varnish, 1.1 varnish"
-            },
-            {
-              "name": "content-length",
-              "value": "15"
-            },
-            {
-              "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:53 GMT"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4057-HHN"
-            },
-            {
-              "name": "x-cache",
-              "value": "MISS, MISS"
-            },
-            {
-              "name": "x-cache-hits",
-              "value": "0, 0"
-            },
-            {
-              "name": "x-timer",
-              "value": "S1578935025.464179,VS0,VE7835"
-            },
-            {
-              "name": "vary",
-              "value": "Accept-Encoding"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000"
-            }
-          ],
-          "headersSize": 500,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 7951,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 7951
+          "wait": 859
         }
       },
       {
@@ -4369,11 +3262,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "978"
+              "value": "909"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -4389,7 +3282,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:53 GMT"
+              "value": "Tue, 21 Jan 2020 13:05:01 GMT"
             },
             {
               "name": "connection",
@@ -4397,7 +3290,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4074-HHN"
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4075-HHN"
             },
             {
               "name": "x-cache",
@@ -4409,7 +3302,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.465418,VS0,VE8516"
+              "value": "S1579611893.771800,VS0,VE8873"
             },
             {
               "name": "vary",
@@ -4426,8 +3319,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 8652,
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 9028,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4435,7 +3328,253 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 8652
+          "wait": 9028
+        }
+      },
+      {
+        "_id": "79c794055d4d1ef5c21ea82386f89a58",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 69,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 69
+            }
+          ],
+          "headersSize": 212,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/5JPU8atUUXBuUOXhK5Zctk/items"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json",
+            "size": 15,
+            "text": "{\"status\":\"ok\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "910"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4053-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.769968,VS0,VE1210"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 1323,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1323
+        }
+      },
+      {
+        "_id": "6e325a205e6e58c3c23fce8cc3c7c1a0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 71,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 71
+            }
+          ],
+          "headersSize": 212,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/1C7mznzU9PHL2isc4Qah6L/items"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json",
+            "size": 15,
+            "text": "{\"status\":\"ok\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "907"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:05:00 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4039-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.774612,VS0,VE8162"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 8285,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 8285
         }
       },
       {
@@ -4492,11 +3631,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "973"
+              "value": "912"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -4512,7 +3651,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:48 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:54 GMT"
             },
             {
               "name": "connection",
@@ -4520,7 +3659,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4066-HHN"
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4055-HHN"
             },
             {
               "name": "x-cache",
@@ -4532,7 +3671,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935025.471190,VS0,VE2715"
+              "value": "S1579611893.773754,VS0,VE1972"
             },
             {
               "name": "vary",
@@ -4549,8 +3688,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:45.378Z",
-        "time": 2830,
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 2088,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4558,7 +3697,1114 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2830
+          "wait": 2088
+        }
+      },
+      {
+        "_id": "ab220a92b4c0a7697e99bcf977dd968c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 64,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 64
+            }
+          ],
+          "headersSize": 212,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/6tmANh9iLMvWGSoWMt2xIe/items"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json",
+            "size": 15,
+            "text": "{\"status\":\"ok\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "905"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:55 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4053-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.770115,VS0,VE2719"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 2835,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2835
+        }
+      },
+      {
+        "_id": "3d491a98af21cdb1e776e8a6ea6a34c3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 74,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 74
+            }
+          ],
+          "headersSize": 212,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/3ovyFLrfhurRT4VXkjCjaq/items"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json",
+            "size": 15,
+            "text": "{\"status\":\"ok\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "916"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:56 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4037-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.768433,VS0,VE3351"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 3459,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 3459
+        }
+      },
+      {
+        "_id": "c43c0e659a406fbd63d1fc67d4e3769e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 64,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 64
+            }
+          ],
+          "headersSize": 212,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/3Im6QICsW4nWwmJfXOnkOG/items"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json",
+            "size": 15,
+            "text": "{\"status\":\"ok\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "913"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:56 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4071-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.771491,VS0,VE3966"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 4090,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4090
+        }
+      },
+      {
+        "_id": "43155cb83343fd49f043888bb36963ca",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 69,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 69
+            }
+          ],
+          "headersSize": 212,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/6tlvGa6erOOoBYRvJT7hS9/items"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json",
+            "size": 15,
+            "text": "{\"status\":\"ok\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "917"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:57 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4072-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.753638,VS0,VE4601"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 4728,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4728
+        }
+      },
+      {
+        "_id": "7e725ab62f2a04a9da3ad178344b2157",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 70,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 70
+            }
+          ],
+          "headersSize": 212,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/5Jdxbb1yW7RnHsZU4r5mF6/items"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json",
+            "size": 15,
+            "text": "{\"status\":\"ok\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "914"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:58 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4059-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.768940,VS0,VE5282"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 5395,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5395
+        }
+      },
+      {
+        "_id": "809698ff1e04f48cfc4b65bb834c4f92",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 73,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 73
+            }
+          ],
+          "headersSize": 212,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/6tmoyiJsES3E5YlwmjF8ls/items"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json",
+            "size": 15,
+            "text": "{\"status\":\"ok\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "911"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:58 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4056-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.772738,VS0,VE5920"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 6060,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6060
+        }
+      },
+      {
+        "_id": "7b0e206504cfabe88c7aaa9ee5c3f86f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 69,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 69
+            }
+          ],
+          "headersSize": 212,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/6tmAIs0aCfNXF6zsmtNScQ/items"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json",
+            "size": 15,
+            "text": "{\"status\":\"ok\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "915"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:59 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4030-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.768038,VS0,VE6526"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 6674,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6674
+        }
+      },
+      {
+        "_id": "1530ba5be5dbd104c47eb031e9094e3a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 70,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 70
+            }
+          ],
+          "headersSize": 212,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/dictionary/6tS8lvtRx0hWi7PATiYTlg/items"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json",
+            "size": 15,
+            "text": "{\"status\":\"ok\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "908"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:59 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4022-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.753590,VS0,VE7197"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 500,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.670Z",
+        "time": 7297,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 7297
+        }
+      },
+      {
+        "_id": "78c79d98212ed3d15368cf37bdd7c7b4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 180992,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "api.fastly.com"
+            },
+            {
+              "name": "content-type",
+              "value": "application/x-www-form-urlencoded"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 180992
+            }
+          ],
+          "headersSize": 217,
+          "httpVersion": "HTTP/1.1",
+          "method": "PUT",
+          "queryString": [],
+          "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/vcl/helix.vcl"
+        },
+        "response": {
+          "bodySize": 104447,
+          "content": {
+            "mimeType": "application/json",
+            "size": 104447,
+            "text": "{\"version\":247,\"updated_at\":\"2020-01-21T13:02:10Z\",\"content\":\"#\\n# Copyright 2018 Adobe. All rights reserved.\\n# This file is licensed to you under the Apache License, Version 2.0 (the \\\"License\\\");\\n# you may not use this file except in compliance with the License. You may obtain a copy\\n# of the License at http://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software distributed under\\n# the License is distributed on an \\\"AS IS\\\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS\\n# OF ANY KIND, either express or implied. See the License for the specific language\\n# governing permissions and limitations under the License.\\n#\\n\\n\\n# About URLs and Host headers:\\n# This VCL will use the following conventions:\\n# `req.url` - The canonical URL, will be used to determine the hash of the object\\n# `req.http.X-Orig-URL` - The URL as received from the client\\n# `req.http.X-Backend-URL` - The URL as should be sent to the origin (backend)\\n#\\n# Having `req.url` be canonical, vs `X-Backend-URL` being what's sent to origin\\n# allows us to do restarts to find content on other origins, and use origin\\n# specific URLs, yet have the object stored under a single hash, meaning that\\n# a cache lookup will find the proper object on the first attempt once an\\n# object is in the cache.\\n#\\n# So `req.url` is what should be left after filtering query string parameters,\\n# doing normalizations, etc. Then `req.http.X-Backend-URL` is a transformation of\\n# that, using the origin specific rewriting, etc.\\n#\\n# Domain names are handled a bit simpler:\\n# `req.http.Host` - The canonical domain name for the site, used for the hash\\n# `req.http.X-Orig-Host` - The original domain name from the client\\n#\\n# `bereq.http.Host` will be set based on the backend used.\\n#\\n# When forwarding the request from edge POP to shield POP, the original URL and\\n# original domain name will be used.\\n\\n# VCL extension points\\ninclude \\\"extensions.vcl\\\";\\n\\n/**\\n * Check the `X-From-Edge` header, which allows us to determine whether\\n * a request is coming from a Fastly edge POP. Use this instead of `Fastly-FF`\\n * since that can be spoofed, or come from another Fastly service.\\n *\\n * This should be called from the very top of `vcl_recv`\\n */\\nsub hlx_check_from_edge {\\n  # Verify correct format\\n  if (req.http.X-From-Edge ~ \\\"^(([0-9]+),[^,]+),(0x[0-9a-f]{64})$\\\"\\n      # Verify the HMAC\\n      \\u0026\\u0026 digest.secure_is_equal(\\n           # Using existing secret, but adding it to service id\\n           # TODO: use a separate secret, because changing it can have some\\n           # gnarly effects, if you don't follow it with a purge all\\n           digest.hmac_sha256(req.service_id + table.lookup(secrets, \\\"OPENWHISK_AUTH\\\")\\n           , re.group.1), re.group.3)) {\\n    declare local var.time TIME;\\n    set var.time = std.time(re.group.2, std.integer2time(-1));\\n    # And verify the timestamp is not off by more than 2 seconds\\n    if (time.is_after(var.time, time.sub(now, 2s))\\n        \\u0026\\u0026 time.is_after(time.add(now, 2s), var.time)) {\\n      # Do nothing, the header is valid\\n      return;\\n    }\\n  }\\n  # Header isn't valid, chuck it\\n  unset req.http.X-From-Edge;\\n}\\n\\n/**\\n * Set the `X-From-Edge` header that the above sub checks.\\n *\\n * Should be called from the top of `vcl_miss`/`vcl_pass`\\n */\\nsub hlx_set_from_edge {\\n  # If it exists, it's legit, leave it alone\\n  if (!bereq.http.X-From-Edge) {\\n    declare local var.data STRING;\\n    set var.data = strftime({\\\"%s\\\"}, now) + \\\",\\\" + server.datacenter;\\n    set bereq.http.X-From-Edge =\\n      var.data + \\\",\\\" + digest.hmac_sha256(\\n        # This must match whatever key is being used\\n        req.service_id + table.lookup(secrets, \\\"OPENWHISK_AUTH\\\"), var.data);\\n  }\\n}\\n\\n/**\\n * Initial processing of request\\n * Does:\\n * - Save original URL/Host\\n * - Unset headers from client\\n * - Setup secure shielding indicator\\n */\\n\\nsub hlx_recv_init {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_recv_init\\\";\\n\\n  # This is set to true for some cases, but that is not cleared upon a restart\\n  set req.hash_always_miss = false;\\n\\n  # Execute the rest only at the very start, not after restarts\\n  if (req.restarts \\u003e 0) {\\n    return;\\n  }\\n\\n  # Check/clear X-From-Edge header\\n  call hlx_check_from_edge;\\n\\n  # Set original URL, so that we can log it afterwards.\\n  set req.http.X-Orig-URL = req.url;\\n  set req.http.X-Orig-Host = req.http.Host;\\n\\n  if (!req.http.X-Debug) {\\n    # Make sure clients can't change request flow\\n    # X-Strain is currently settable by Cookie, not worth unsetting for now\\n    unset req.http.X-Backend-URL;\\n    unset req.http.X-Dirname;\\n    unset req.http.X-Request-Type;\\n    unset req.http.X-Static-Content-Type;\\n    unset req.http.X-Sticky;\\n    # Allow through from another Fastly POP as well as from debugger\\n    if (!req.http.X-From-Edge) {\\n      unset req.http.X-CDN-Request-ID;\\n    }\\n  }\\n\\n  # Force HTTPS\\n  if (!req.http.Fastly-SSL) {\\n     error 801 \\\"Force SSL\\\";\\n  }\\n\\n  # Set a unique ID if not present\\n  if (!req.http.X-CDN-Request-ID) {\\n    set req.http.X-CDN-Request-ID = randomstr(8, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(4, \\\"0123456789abcdef\\\") + \\\"-4\\\" + randomstr(3, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(1, \\\"89ab\\\") + randomstr(3, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(12, \\\"0123456789abcdef\\\");\\n  }\\n\\n  # set X-Version initial value\\n  set req.http.X-Version = regsub(req.vcl, \\\"([^.]+)\\\\.(\\\\d+)_(\\\\d+)-(.*)\\\", \\\"\\\\2\\\");\\n\\n}\\n\\n\\n# Determines the current strain, and sets the X-Strain header\\nsub hlx_strain {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_strain\\\";\\n  # TODO: add X-Strain-Key as a random-generated, validation property\\n  if (req.http.X-Strain) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(header:\\\" + req.http.X-Strain + \\\")\\\";\\n  }\\n  # read strain from URL query string\\n  if (subfield(req.url.qs, \\\"hlx_strain\\\", \\\"\\u0026\\\")) {\\n    set req.http.X-Strain = subfield(req.url.qs, \\\"hlx_strain\\\", \\\"\\u0026\\\");\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(url)\\\";\\n  }\\n  # read strain from Cookie\\n  if (req.http.Cookie:X-Strain) {\\n    set req.http.X-Strain = req.http.Cookie:X-Strain;\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(cookie)\\\";\\n  }\\n\\n  # Sanitize user input. `urlencode` leaves alphanumeric and `-._~`\\n  set req.http.X-Strain = regsuball(urlencode(req.http.X-Strain), {\\\"%..\\\"}, \\\"_\\\");\\n\\n  # do not override strain if set in header\\n  if (!req.http.X-Strain||req.http.X-Strain==\\\"\\\") {\\n    set req.http.X-Strain = \\\"default\\\";\\n\\n    # run custom strain resolution\\n    include \\\"strains.vcl\\\";\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(resolved)\\\";\\n  }\\n\\n  # we don't need cookies for anything else, but Proxy strains might\\n  if (req.http.X-Request-Type != \\\"Proxy\\\") {\\n    unset req.http.Cookie;\\n  }\\n}\\n\\n# Gets the content whitelist for the current strain and sets the X-Allow header\\nsub hlx_allow {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_allow\\\";\\n\\n  # starting permissive – change this for a more restrictive default\\n  set req.http.X-Allow = table.lookup(strain_allow, req.http.X-Strain);\\n  if (!req.http.X-Allow) {\\n    set req.http.X-Allow = table.lookup(strain_allow, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the content blacklist for the current strain and sets the X-Deny header\\nsub hlx_deny {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deny\\\";\\n\\n  set req.http.X-Deny = table.lookup(strain_deny, req.http.X-Strain);\\n  if (!req.http.X-Deny) {\\n    set req.http.X-Deny = table.lookup(strain_deny, \\\"default\\\");\\n  }\\n}\\n\\n# Implements the content block list (to be called from vcl_recv)\\nsub hlx_block_recv {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_block_recv\\\";\\n\\n  call hlx_deny;\\n  call hlx_allow;\\n}\\n\\n# Gets the content owner for the current strain and sets the X-Owner header\\nsub hlx_owner {\\n  call hlx_owner_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_owner\\\";\\n\\n  set req.http.X-Owner = table.lookup(strain_owners, req.http.X-Strain);\\n  if (!req.http.X-Owner) {\\n    set req.http.X-Owner = table.lookup(strain_owners, \\\"default\\\");\\n  }\\n\\n  call hlx_owner_after;\\n}\\n\\n# Gets the directory index for the current strain\\nsub hlx_index {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_index\\\";\\n\\n  set req.http.X-Index = table.lookup(strain_index_files, req.http.X-Strain);\\n  if (!req.http.X-Index) {\\n    set req.http.X-Index = table.lookup(strain_index_files, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the content repo\\nsub hlx_repo {\\n  call hlx_repo_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_repo\\\";\\n  set req.http.X-Repo = table.lookup(strain_repos, req.http.X-Strain);\\n  if (!req.http.X-Repo) {\\n    set req.http.X-Repo = table.lookup(strain_repos, \\\"default\\\");\\n  }\\n\\n  call hlx_repo_after;\\n}\\n\\n# Gets the content ref\\nsub hlx_ref {\\n  call hlx_ref_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_ref\\\";\\n  set req.http.X-Ref = table.lookup(strain_refs, req.http.X-Strain);\\n  # fall back to default strain\\n  if (!req.http.X-Ref) {\\n    set req.http.X-Ref = table.lookup(strain_refs, \\\"default\\\");\\n  }\\n  # if default isn't set, use 'master'\\n  if (!req.http.X-Ref) {\\n    set req.http.X-Ref = \\\"master\\\";\\n  }\\n\\n  call hlx_ref_after;\\n}\\n\\n# Gets the content path root\\nsub hlx_root_path {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_root_path\\\";\\n  set req.http.X-Repo-Root-Path = table.lookup(strain_root_paths, req.http.X-Strain);\\n  if (!req.http.X-Repo-Root-Path) {\\n    set req.http.X-Repo-Root-Path = table.lookup(strain_root_paths, \\\"default\\\");\\n  }\\n  if (!req.http.X-Repo-Root-Path) {\\n    set req.http.X-Repo-Root-Path = \\\"\\\";\\n  }\\n}\\n\\nsub hlx_action_root {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_action_root\\\";\\n  set req.http.X-Action-Root = table.lookup(strain_action_roots, req.http.X-Strain);\\n  if (!req.http.X-Action-Root) {\\n    set req.http.X-Action-Root = table.lookup(strain_action_roots, \\\"default\\\");\\n  }\\n  #set req.http.X-Action-Root = \\\"/trieloff/default/git-github-com-adobe-helix-cli-git--dirty--\\\";\\n}\\n\\n# Gets the github static repo\\nsub hlx_github_static_repo {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_repo\\\";\\n  set req.http.X-Github-Static-Repo = table.lookup(strain_github_static_repos, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Repo) {\\n    set req.http.X-Github-Static-Repo = table.lookup(strain_github_static_repos, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the github static owner\\nsub hlx_github_static_owner {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_owner\\\";\\n  set req.http.X-Github-Static-Owner = table.lookup(strain_github_static_owners, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Owner) {\\n    set req.http.X-Github-Static-Owner = table.lookup(strain_github_static_owners, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the github static root\\nsub hlx_github_static_root {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_root\\\";\\n  set req.http.X-Github-Static-Root = table.lookup(strain_github_static_root, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Root) {\\n    set req.http.X-Github-Static-Root = table.lookup(strain_github_static_root, \\\"default\\\");\\n  }\\n  if (!req.http.X-Github-Static-Root) {\\n    set req.http.X-Github-Static-Root = \\\"/\\\";\\n  }\\n  set req.http.X-Trace = req.http.X-Trace + \\\"(\\\" + req.http.X-Github-Static-Root +  \\\")\\\";\\n}\\n\\n# Gets the github static ref\\nsub hlx_github_static_ref {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_ref\\\";\\n  set req.http.X-Github-Static-Ref = table.lookup(strain_github_static_refs, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Ref) {\\n    set req.http.X-Github-Static-Ref = table.lookup(strain_github_static_refs, \\\"default\\\");\\n  }\\n}\\n\\n# rewrite required headers (called from fetch)\\nsub hlx_headers_fetch {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_headers_fetch\\\";\\n\\n  # Add Surrogate-Key headers for soft purges\\n  if (!beresp.http.Surrogate-Key) {\\n    set beresp.http.Surrogate-Key = \\\"all\\\";\\n  } else{\\n    set beresp.http.Surrogate-Key = \\\"all \\\" + beresp.http.Surrogate-Key;\\n  }\\n\\n  # Only do this when X-Debug is present, since `Vary: X-Debug` will cause\\n  # misses, making it useless to keep this on regular objects.\\n  if (req.http.X-Debug) {\\n    if (!beresp.http.X-Backend-Name) {\\n      set beresp.http.X-Backend-Name = beresp.backend.name;\\n    }\\n    if (!beresp.http.X-CDN-Request-ID) {\\n      set beresp.http.X-CDN-Request-ID = req.http.X-CDN-Request-ID;\\n    }\\n  }\\n}\\n\\nsub hlx_headers_deliver {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_headers_deliver\\\";\\n\\n  # Set HSTS since we always do HTTPS\\n  set resp.http.Strict-Transport-Security = \\\"max-age=31536000\\\";\\n\\n  set resp.http.X-Version = req.http.X-Version;\\n\\n  if( req.http.X-Debug ) {\\n    set resp.http.X-URL = req.url;\\n    set resp.http.X-Orig-Url = req.http.X-Orig-Url;\\n    set resp.http.X-Backend-URL = req.http.X-Backend-URL;\\n    set resp.http.X-Request-Type = req.http.X-Request-Type;\\n    set resp.http.X-Strain = req.http.X-Strain;\\n    set resp.http.X-Github-Static-Ref = \\\"@\\\" + req.http.X-Github-Static-Ref;\\n\\n    set resp.http.X-Dirname = req.http.X-Dirname;\\n    set resp.http.X-FullDirname = req.http.X-FullDirname;\\n    set resp.http.X-Index = req.http.X-Index;\\n    set resp.http.X-Action-Root = req.http.X-Action-Root;\\n    set resp.http.X-Orig-URL = req.http.X-Orig-URL;\\n    set resp.http.X-Repo-Root-Path = req.http.X-Repo-Root-Path;\\n\\n    set resp.http.X-Fastly-Imageopto-Api = req.http.X-Fastly-Imageopto-Api;\\n\\n    set resp.http.X-Embed = req.http.X-Embed;\\n\\n    set resp.http.X-Trace = req.http.X-Trace;\\n }\\n\\n  call hlx_deliver_errors;\\n}\\n\\nsub hlx_determine_request_type {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_determine_request_type\\\";\\n  // TODO check for topurl\\n  if (req.url.ext == \\\"url\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(static-url)\\\";\\n    set req.http.X-Request-Type = \\\"Static-URL\\\";\\n    return;\\n  }\\n\\n  // TODO check for topurl\\n  if (req.url.ext == \\\"302\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(static-302)\\\";\\n    set req.http.X-Request-Type = \\\"Static-302\\\";\\n    return;\\n  }\\n\\n  # Exit if we already have a type\\n  if (req.http.X-Request-Type) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(existing:\\\" + req.http.X-Request-Type + \\\")\\\" ;\\n    return;\\n  }\\n\\n  // something like https://hlx.blob.core.windows.net/external/098af326aa856bb42ce9a21240cf73d6f64b0b45\\n  if (req.url.path ~ \\\"^/(hlx_([0-9a-f]){40}).(jpg|jpeg|png|webp|gif)$\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(blob)\\\";\\n    set req.http.X-Request-Type = \\\"Blob\\\";\\n    unset req.http.Accept-Encoding;\\n    return;\\n  }\\n\\n  // something like /_query/index/name\\n  if (req.url.path ~ \\\"^/_query/.+/.+$\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(query)\\\";\\n    set req.http.X-Request-Type = \\\"Query\\\";\\n    unset req.http.Accept-Encoding;\\n    return;\\n  }\\n\\n  if (req.url.ext ~ \\\"^(hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n    set req.http.X-Request-Type = \\\"Static\\\";\\n    unset req.http.Accept-Encoding;\\n    return;\\n  }\\n\\n  if (req.http.host == \\\"adobeioruntime.net\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(embed)\\\";\\n    set req.http.X-Request-Type = \\\"Embed\\\";\\n    return;\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"(none)\\\";\\n}\\n\\n/**\\n * This subroutine implements static resource prefetching by calling Adobe I/O Runtime\\n * @header X-GitHub-Static-Owner  the owner or organization of the repo that contains the source files\\n * @header X-GitHub-Static-Repo   the repository name of the repo containing the static files\\n * @header X-GitHub-Static-Ref    the branch or tag (or commit) name to serve source files from\\n * @header X-Orig-URL             the original (unmodified) URL, starting after hostname and port\\n */\\nsub hlx_type_static_url {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_static_url\\\";\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.path STRING; # resource path\\n\\n  # Load important information from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n  # TODO: check for URL ending with `/` and look up index file\\n  set var.path = regsub(req.http.X-Orig-URL, \\\".(url|302)$\\\", \\\"\\\");\\n\\n  set req.http.X-Action-Root = \\\"/api/v1/web/\\\" + table.lookup(secrets, \\\"OPENWHISK_NAMESPACE\\\") + \\\"/helix-services/static@v1\\\";\\n  set req.http.X-Backend-URL = req.http.X-Action-Root\\n    + \\\"?owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026path=\\\" + var.path\\n    # TODO: load magic flag\\n    + \\\"\\u0026plain=true\\\"\\n    + \\\"\\u0026allow=\\\" urlencode(req.http.X-Allow)\\n    + \\\"\\u0026deny=\\\" urlencode(req.http.X-Deny)\\n    + \\\"\\u0026root=\\\" + req.http.X-Github-Static-Root;\\n}\\n\\n/**\\n * This subroutine implements static file handling by calling\\n * the hlx--static action in OpenWhisk\\n * @header X-GitHub-Static-Owner  the owner or organization of the repo that contains the source files\\n * @header X-GitHub-Static-Repo   the repository name of the repo containing the static files\\n * @header X-GitHub-Static-Ref    the branch or tag (or commit) name to serve source files from\\n * @header X-Orig-URL             the original (unmodified) URL, starting after hostname and port\\n */\\nsub hlx_type_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_static\\\";\\n  # This is a static request.\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.path STRING; # resource path\\n  declare local var.esi STRING;\\n\\n  # Load important information from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n\\n  # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441\\n  if (req.url ~ \\\"^(.*)(.hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n    # and keep only the non-hashed part, i.e. everything before .hlx_\\n    set var.path = re.group.1;\\n    set var.esi = \\\"\\u0026esi=true\\\";\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(normal)\\\";\\n    # TODO: check for URL ending with `/` and look up index file\\n    set var.path = req.url;\\n    set var.esi = \\\"\\\";\\n  }\\n  set var.path = regsuball(var.path, \\\"/+\\\", \\\"/\\\");\\n\\n  set req.http.X-Action-Root = \\\"/api/v1/web/\\\" + table.lookup(secrets, \\\"OPENWHISK_NAMESPACE\\\") + \\\"/helix-services/static@v1\\\";\\n  set req.http.X-Backend-URL = req.http.X-Action-Root\\n    + \\\"?owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026path=\\\" + var.path\\n    + var.esi\\n    # TODO: load magic flag\\n    + \\\"\\u0026plain=true\\\"\\n    + \\\"\\u0026allow=\\\" urlencode(req.http.X-Allow)\\n    + \\\"\\u0026deny=\\\" urlencode(req.http.X-Deny)\\n    + \\\"\\u0026root=\\\" + req.http.X-Github-Static-Root;\\n}\\n\\nsub hlx_type_blob {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_blob\\\";\\n  # This is a blob request.\\n\\n  # get it from Azure Blob Storage\\n  set req.backend = F_AzureBlobs;\\n\\n  declare local var.sha STRING;\\n  declare local var.ext STRING;\\n\\n  if (req.url.path ~ \\\"^/hlx_(([0-9a-f]){40}).(jpg|jpeg|png|webp|gif)$\\\") {\\n    set var.sha = re.group.1;\\n    set var.ext = req.url.ext;\\n\\n    # TODO verify\\n    set req.http.X-Fastly-Imageopto-Api = \\\"fastly\\\";\\n  }\\n\\n  set req.http.X-Backend-URL = \\\"/external/\\\" + var.sha;\\n}\\n\\nsub hlx_type_query {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_query\\\";\\n  # yes, it's a query request\\n\\n  # get it from Algolia\\n  set req.backend = F_Algolia;\\n\\n  # Load important information for content repo from edge dicts\\n  call hlx_owner;\\n  call hlx_repo;\\n\\n  # run map queries\\n  include \\\"queries.vcl\\\";\\n}\\n\\n\\n/**\\n * Handle redirect-serving for static files\\n * If the static file is too large for the hlx--static action to serve,\\n * because the payload would exceed 1 MB (OpenWhisk limit), the request\\n * is restarted, using the `X-Request-Type: Redirect` header, which means the\\n * static content will be fetched directly from GitHub, and the required\\n * response headers like Content-Type will be injected later on.\\n */\\nsub hlx_type_redirect {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_redirect\\\";\\n  # Handle a redirect from static.js by\\n  # - fetching the resource from GitHub\\n  # - don't forget to override the Content-Type header\\n  set req.backend = F_GitHub;\\n  # Replace what we have in the cache already (which is the cached redirect)\\n  set req.hash_always_miss = true;\\n}\\n\\nsub hlx_fetch_blob {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_blob\\\";\\n  if (req.http.X-Request-Type == \\\"Blob\\\" \\u0026\\u0026 beresp.status == 200) {\\n    # The URLs are a hash of the content, so we can cache stuff for a year\\n    # both on the edge and in the browser\\n    set beresp.http.Cache-Control = \\\"max-age=31622400,immutable\\\";\\n    set beresp.http.Surrogate-Control = \\\"max-age=31622400,immutable\\\";\\n    set beresp.cacheable = true;\\n    set beresp.ttl = 31622400s;\\n\\n    if (!req.http.X-Debug) {\\n      # shut up chatty headers\\n      unset beresp.http.x-ms-blob-type;\\n      unset beresp.http.x-ms-lease-state;\\n      unset beresp.http.x-ms-lease-status;\\n      unset beresp.http.x-ms-request-id;\\n      unset beresp.http.x-ms-version;\\n      unset beresp.http.Server;\\n    }\\n\\n    # TODO: should we set req.http.X-Fastly-Imageopto-Api ?\\n\\n    return(deliver);\\n  }\\n}\\n\\nsub hlx_fetch_query {\\n  if (req.http.X-Request-Type == \\\"Blob\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_query\\\";\\n\\n    # use the cache settings configured for the query\\n    set beresp.http.Surrogate-Control = req.http.X-Surrogate-Control;\\n  }\\n}\\n\\nsub hlx_fetch_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_static\\\";\\n  declare local var.ext STRING;\\n\\n  if (req.http.X-Request-Type == \\\"Static-URL\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(url)\\\";\\n    # Get the ETag response header and use it to construct a stable URL\\n\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n    set req.http.X-Trace = req.http.X-Trace + \\\"[url=\\\" + req.http.X-Orig-URL + \\\", ext=\\\" + var.ext + \\\"]\\\";\\n    set req.http.X-Location = regsub(req.http.X-Orig-URL, \\\".url$\\\", var.ext);\\n    error 303 \\\"URL\\\";\\n  }\\n  if (req.http.X-Request-Type == \\\"Static-302\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(302)\\\";\\n    # Get the ETag response header and use it to construct a stable URL\\n\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n    set req.http.X-Trace = req.http.X-Trace + \\\"[url=\\\" + req.http.X-Orig-URL + \\\", ext=\\\" + var.ext + \\\"]\\\";\\n    set req.http.X-Location = regsub(req.http.X-Orig-URL, \\\".302$\\\", var.ext);\\n    error 902 \\\"302\\\";\\n  }\\n  # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441\\n  if (req.http.X-Orig-URL ~ \\\"^(.*)(.hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n\\n    if (re.group.2 == var.ext) {\\n      set req.esi = true;\\n      esi;\\n      set beresp.http.X-ESI = \\\"processed(\\\" + bereq.http.Accept-Encoding + \\\", \\\" + req.esi + \\\",\\\" + req.http.X-From-Edge +\\\")\\\";\\n      set beresp.http.x-compress-hint = \\\"on\\\"; // so h2o compresses it on the way out\\n      set beresp.http.Cache-Control = \\\"max-age=31622400,immutable\\\"; # keep it for a year in the browser;\\n      set beresp.http.Surrogate-Control = \\\"max-age=31622400,immutable\\\";\\n      set beresp.cacheable = true;\\n      set beresp.ttl = 31622400s;\\n    } else {\\n      set beresp.ttl = 300s;\\n      error 404 \\\"Invalid\\\";\\n      set beresp.http.X-Trace = \\\"etag=\\\" + beresp.http.ETag + \\\"; ext=\\\" + var.ext;\\n\\n    }\\n    return(deliver);\\n  }\\n  if (beresp.http.X-Static == \\\"Raw/Static\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(raw)\\\";\\n    if (beresp.status == 307) {\\n      # Keep the redirect around for a short bit, to prevent thundering herd\\n      set beresp.cacheable = true;\\n      set beresp.ttl = 5s;\\n    }\\n    return(deliver);\\n  } elsif (req.http.X-Request-Type == \\\"Redirect\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(redirect)\\\";\\n    // and this is where we fix the headers of the GitHub static response\\n    // so that they become digestible by a browser.\\n    // - recover Content-Type from X-Content-Type\\n    // - filter out GitHub-headers\\n\\n    set beresp.http.Content-Type = req.http.X-Static-Content-Type;\\n    unset beresp.http.X-Content-Type-Options;\\n    unset beresp.http.X-Frame-Options;\\n    unset beresp.http.X-XSS-Protection;\\n    unset beresp.http.Content-Security-Policy;\\n  } elsif (beresp.status == 404 || beresp.status == 204) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(400)\\\";\\n    # Cache for a short time, restart will get rid of it anyway\\n    set beresp.ttl = 60s;\\n    return(deliver);\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(none)\\\";\\n  }\\n}\\n\\n/**\\n * Fallback handling. Depending on the previous step and the previous status code, either\\n * deliver or restart.\\n */\\nsub hlx_deliver_type {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_type(\\\" + req.http.X-Request-Type + \\\")\\\";\\n  if (req.http.X-Request-Type == \\\"Dispatch\\\") {\\n    call hlx_deliver_static;\\n  }\\n}\\n\\n/**\\n * Handle the delivery of error handlers. There are two scenarios here:\\n * 1. either the error page could be delivered from dispatch, then do nothing\\n * 2. no error page could be found, so set the correct status code and deliver a fallback\\n */\\nsub hlx_fetch_error {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_error(\\\" + beresp.status + \\\")\\\";\\n  # only use syntethic errors if not in esi sub-request and no content is delivered from the dispatcher.\\n  if (!req.http.x-topurl \\u0026\\u0026 beresp.status != 200 \\u0026\\u0026 beresp.http.Content-Length == \\\"0\\\") {\\n    # TODO: fix headers\\n    if (beresp.status == 404) {\\n       error 951 \\\"Not Found\\\";\\n    } else {\\n       error 952 \\\"Internal Server Error\\\";\\n    }\\n  }\\n  # if (req.url.basename ~ \\\"^([0-9][0-9][0-9])\\\") {\\n  #   set beresp.status = std.atoi(re.group.1);\\n  # } else {\\n  #   # this should never happen\\n  #   set beresp.status = 500;\\n  # }\\n}\\n\\n/**\\n * Handle delivery of static stuff. If there is a 404, restart with error\\n * if there is content, just deliver it. If there is a redirect, fetch\\n * from redirect and adjust headers\\n */\\nsub hlx_deliver_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_static\\\";\\n  if (resp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(ok)\\\";\\n    return;\\n  } elsif (resp.status == 307) {\\n    # perform some additional validation\\n    if (resp.http.Location ~ \\\"https://raw.githubusercontent.com(/.*)\\\") {\\n      set req.http.X-Request-Type = \\\"Redirect\\\";\\n      set req.http.X-Backend-URL = re.group.1;\\n      set req.http.X-Static-Content-Type = resp.http.X-Content-Type;\\n      set req.http.X-Trace = req.http.X-Trace + \\\"(redirect)\\\";\\n      restart;\\n    } else {\\n      set resp.status = 500;\\n      set resp.response = \\\"Redirect to wrong hostname\\\";\\n      set req.http.X-Trace = req.http.X-Trace + \\\"(redirect-error)\\\";\\n    }\\n  } else {\\n    # any other error, ignore\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(error)\\\";\\n    #set req.http.X-Request-Type = \\\"Error\\\";\\n    #set req.url = \\\"/\\\" + resp.status + \\\".html\\\"; // fall back to 500.html\\n    #restart;\\n  }\\n}\\n\\n/**\\n * Handle requests to Adobe I/O Runtime services.\\n * When Fastly handles ESI requests to 3rd-party domains, they still get routed\\n * through this service. In this method we make sure that ESI requests destined\\n * for Adobe I/O Runtime, e.g. the helix-embed service are passed through to\\n * the correct backend.\\n */\\nsub hlx_type_embed {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_embed\\\";\\n  # This is an embed request\\n  # Fastly sends embed requests back to the same service config (which is why\\n  # we are handling it here), but keeps the correct Host header in place (which\\n  # is why we can check against it)\\n  set req.backend = F_AdobeRuntime;\\n}\\n\\n\\n/**\\n * Handles requests for the main Helix rendering pipeline.\\n */\\nsub hlx_type_dispatch {\\n  call hlx_type_pipeline_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_dispatch\\\";\\n  # This is a dynamic request.\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.action STRING; # the action to call\\n  declare local var.namespace STRING;\\n  declare local var.package STRING;\\n\\n  # Load important information for content repo from edge dicts\\n  call hlx_owner;\\n  call hlx_repo;\\n  call hlx_ref;\\n  call hlx_root_path;\\n  call hlx_index;\\n\\n  # Load important information for fallback repo from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n\\n  # enable ESI\\n  # TODO: move to dispatch action\\n  set req.http.x-esi = \\\"1\\\";\\n\\n\\n  # sets X-Action-Root to something like trieloff/b7aa8a6351215b7e12b6d3be242c622410c1eb28\\n  call hlx_action_root;\\n  set var.namespace = regsuball(req.http.X-Action-Root, \\\"/.*$\\\", \\\"\\\"); // cut away the slash and everything after it\\n  set var.package = regsuball(req.http.X-Action-Root, \\\"^.*/\\\", \\\"\\\"); // cut away everything from the start up to (including) the slash\\n\\n\\n  # get (strain-specific) parameter whitelist\\n  include \\\"params.vcl\\\";\\n\\n  set req.http.X-Backend-URL = \\\"/api/v1/web\\\"\\n    + \\\"/\\\" + var.namespace // i.e. /trieloff\\n    + \\\"/helix-services/dispatch@\\\" + req.http.X-Dispatch-Version\\n    // fallback repo\\n    + \\\"?static.owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026static.repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026static.ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026static.root=\\\" + req.http.X-Github-Static-Root\\n    // content repo\\n    + \\\"\\u0026content.owner=\\\" + req.http.X-Owner\\n    + \\\"\\u0026content.repo=\\\" + req.http.X-Repo\\n    + \\\"\\u0026content.ref=\\\" + req.http.X-Ref\\n    + \\\"\\u0026content.root=\\\" + req.http.X-Repo-Root-Path\\n    + \\\"\\u0026content.package=\\\" + var.package\\n    + \\\"\\u0026content.index=\\\" + req.http.X-Index\\n    + \\\"\\u0026path=\\\" + req.url.path\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026rootPath=\\\" + req.http.X-Root-Path;\\n\\n  # only append the encoded params if there are encoded params\\n  if (req.http.X-Encoded-Params) {\\n    set req.http.X-Backend-URL = req.http.X-Backend-URL\\n      + \\\"\\u0026params=\\\" + req.http.X-Encoded-Params;\\n  }\\n\\n  call hlx_type_pipeline_after;\\n}\\n\\n/**\\n * Handle requests to Proxy Strains.\\n * These requests already have a backend set as part of the strain resolution\\n * so there is no need for URL rewriting.\\n */\\nsub hlx_type_proxy {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_proxy\\\";\\n  # TODO: set Forwarded header? (RFC7239)\\n  # TODO: Host header/URL rewrites? or all done at strain resolution time?\\n\\n  # Pass here so that `dynamic.vcl` doesn't execute for Proxy requests\\n  # And we do a pass, not a lookup, because caching third parties is way too\\n  # risky, and would take a lot of work in `vcl_fetch` to get right.\\n  return(pass);\\n}\\n\\n/**\\n  This checks X-Debug key\\n*/\\nsub hlx_check_debug_key {\\n  declare local var.debugSecret STRING;\\n  declare local var.key STRING;\\n  declare local var.level STRING;\\n\\n  set var.debugSecret = table.lookup(secrets, \\\"DEBUG_KEY\\\");\\n  set var.key = regsub(req.http.X-Debug, \\\":.*$\\\", \\\"\\\");\\n\\n  if (req.http.X-Debug ~ \\\":\\\") {\\n    set var.level = regsub(req.http.X-Debug, \\\"^.*:\\\", \\\"\\\");\\n  } else {\\n    set var.level = \\\"debug\\\";\\n  }\\n\\n  //X-Debug must be protected\\n  if (var.debugSecret \\u0026\\u0026 var.key == var.debugSecret) {\\n    set req.http.X-Debug = var.level;\\n  } else {\\n    unset req.http.X-Debug;\\n  }\\n}\\n\\n/**\\n * This is where all requests are received.\\n */\\nsub vcl_recv {\\n  if (req.restarts == 0) {\\n    if (req.http.X-Trace) {\\n      set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_recv\\\";\\n    } else {\\n      set req.http.X-Trace = \\\"vcl_recv\\\";\\n    }\\n  } else {\\n    # So we don't have to add `RESTART` to `X-Trace` whenever we use `restart`\\n    set req.http.X-Trace = req.http.X-Trace + \\\"; RESTART; vcl_recv\\\";\\n  }\\n\\n  call hlx_check_debug_key;\\n  call hlx_recv_init;\\n\\n  # run generated vcl\\n  include \\\"dynamic.vcl\\\";\\n\\n#FASTLY recv\\n\\n  # X-Location gets set by Helix's redirect logic inside the FASTLY recv block\\n  # that will get injected above.\\n  if (req.http.X-Location) {\\n    error 301 \\\"Redirect\\\";\\n  }\\n\\n  # TODO: Do we even want to set a regular origin as default? Possibly set one\\n  # that acts as a canary. If requests reach it, the VCL isn't setting a backend\\n  # somewhere.\\n  set req.backend = F_AdobeRuntime;\\n\\n  if (req.http.X-From-Edge) {\\n    # Request came from a Fastly POP, send the raw response without ESI processing\\n    set req.esi = false;\\n  } elseif ( req.url.ext == \\\"html\\\" ) {\\n    set req.http.x-esi = \\\"1\\\";\\n  }\\n\\n  # somehow we don't see the req.topurl in vcl_fetch, so we remember it here\\n  if (req.topurl) {\\n    set req.http.x-topurl = req.topurl;\\n  }\\n\\n  // compute X-FullDirname which contains the real incoming path of directories\\n  if (req.url.ext == \\\"\\\") {\\n    // case url = /a/b -\\u003e for Fastly, dirname = /a and basename = b\\n    set req.http.X-FullDirname = req.url.dirname + \\\"/\\\" + req.url.basename;\\n  } else {\\n    // case url = /a/b/c.html -\\u003e for Fastly, dirname = /a/b which is what we need\\n    set req.http.X-FullDirname = req.url.dirname;\\n  }\\n  // remove potential double slashes\\n  set req.http.X-FullDirname = regsuball(req.http.X-FullDirname, \\\"/+\\\", \\\"/\\\");\\n\\n  # Determine the current strain and execute strain-specific code\\n  call hlx_strain;\\n\\n  # block bad requests – needs current strain and unchanged req.url\\n  call hlx_block_recv;\\n\\n  # Must be after `hlx_strain`, because that might set `Proxy` as type\\n  call hlx_determine_request_type;\\n\\n  # Force clustering (despite the name of the header) to make sure we get good\\n  # cache efficiency with restarts. Without this, Fastly clustering would be\\n  # disabled after a restart, which means that each node in a Fastly POP would\\n  # use its own cache, instead of checking the designated node for the object.\\n  set req.http.Fastly-Force-Shield = \\\"yes\\\";\\n\\n  if (req.http.X-Request-Type == \\\"Proxy\\\") {\\n    call hlx_type_proxy;\\n  } elsif (req.http.X-Request-Type == \\\"Static\\\") {\\n    call hlx_type_static;\\n  } elsif (req.http.X-Request-Type == \\\"Blob\\\") {\\n    call hlx_type_blob;\\n  } elsif (req.http.X-Request-Type == \\\"Query\\\") {\\n    call hlx_type_query;\\n  } elsif (req.http.X-Request-Type == \\\"Redirect\\\") {\\n    call hlx_type_redirect;\\n  } elsif (req.http.X-Request-Type == \\\"Embed\\\") {\\n    call hlx_type_embed;\\n  } elseif (req.http.X-Request-Type == \\\"Static-URL\\\") {\\n    call hlx_type_static_url;\\n  } elseif (req.http.X-Request-Type == \\\"Static-302\\\") {\\n    call hlx_type_static_url;\\n  } else {\\n    set req.http.X-Request-Type = \\\"Dispatch\\\";\\n    call hlx_type_dispatch;\\n  }\\n\\n  # re-enable shielding for changed backends\\n  # include \\\"reset.vcl\\\";\\n\\n  # We only handle GET and HEAD requests, but Proxy strains might\\n  if (req.request != \\\"HEAD\\\" \\u0026\\u0026 req.request != \\\"GET\\\" \\u0026\\u0026 req.request != \\\"FASTLYPURGE\\\") {\\n    error 405;\\n  }\\n\\n  return(lookup);\\n}\\n\\nsub hlx_fetch_errors {\\n  if (req.http.x-topurl) {\\n    # don't set syntethic error for ESI sub-requests\\n    return;\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_errors\\\";\\n  # Interpreting OpenWhisk errors is a bit tricky, because we don't have access to the JSON\\n  # of the response body. Instead we are using the Content-Length of known error messages\\n  # to determine the most likely root cause. Each root cause will get an internal status code\\n  # starting with 951, which is then handled by `hlx_error_errors` and `hlx_deliver_errors`\\n  if ( beresp.status == 404 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"74\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 951 \\\"Unknown Extension\\\";\\n  }\\n\\n  if ( beresp.status == 404 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"69\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 952 \\\"Wrong Code Path\\\";\\n  }\\n\\n  if ( beresp.status == 401 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"65\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 953 \\\"Can't Call Action\\\";\\n  }\\n}\\n\\nsub hlx_deliver_errors {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_errors\\\";\\n\\n  # Cache Condition: OpenWhisk Error Prio: 10\\n  if (resp.status == 951 ) {\\n     set resp.status = 404;\\n     set resp.response = \\\"Not Found\\\";\\n  }\\n  if (resp.status == 952 ) {\\n     set resp.status = 500;\\n     set resp.response = \\\"Internal Server Error\\\";\\n  }\\n  if (resp.status == 953 ) {\\n     set resp.status = 500;\\n     set resp.response = \\\"Internal Server Error\\\";\\n  }\\n  if (resp.status == 954) {\\n    if (req.url.basename ~ \\\"^([0-9][0-9][0-9])\\\") {\\n      set resp.status = std.atoi(re.group.1);\\n    } else {\\n      # this should never happen\\n      set resp.status = 500;\\n    }\\n  }\\n}\\n\\nsub hlx_error_errors {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_error_errors\\\";\\n  # Cache Condition: OpenWhisk Error Prio: 10\\n  if (obj.status == 951 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eResource not Found\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n\\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n\\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n\\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n\\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n\\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n\\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite;\\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6;\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e404\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eRESOURCE\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eNOT FOUND\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThe requested resource could not be found..\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\n\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 952 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n\\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n\\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n\\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n\\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n\\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n\\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite;\\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6;\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThere was an error processing your request.\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\n\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 953 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThe configured backend authentication has been rejected.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 954) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    if (req.url.basename ~ \\\"^404\\\") {\\n      synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eResource not found\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n          \\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n            \\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n            \\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n            \\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n            \\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n            \\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite; \\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6; \\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8; \\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8; \\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }    \\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e404\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eRESOURCE\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eNOT FOUND\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThe requested resource could not be found.\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\\"};\\n      return(deliver);\\n    }\\n    if (req.url.basename ~ \\\"^500\\\") {\\n      synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThere was an error processing your request.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n      return(deliver);\\n    }\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThere was an unknown error processing your request.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n    return(deliver);\\n  }\\n}\\n\\nsub vcl_fetch {\\n  # store trace information in backend response headers in order\\n  # to make them available in vcl_deliver\\n  set beresp.http.X-Trace = req.http.X-Trace;\\n  set beresp.http.X-PreFetch-Pass = req.http.X-PreFetch-Pass;\\n  set beresp.http.X-PreFetch-Miss = req.http.X-PreFetch-Miss;\\n  set beresp.http.X-PostFetch = \\\"; vcl_fetch(\\\" beresp.status \\\": \\\" req.url \\\" \\\" req.http.X-Request-Type \\\")\\\";\\n#FASTLY fetch\\n\\n  # Sprinkling in our debugging\\n  call hlx_headers_fetch;\\n\\n  # Don't try to do anything else with Proxy requests\\n  if (req.http.X-Request-Type == \\\"Proxy\\\") {\\n    return(pass);\\n  }\\n\\n  call hlx_fetch_errors;\\n\\n  unset beresp.http.Set-Cookie;\\n  unset beresp.http.Vary;\\n  unset beresp.http.Expires;\\n\\n  # We Vary on X-Debug, so that it's automatically a cache-miss, and we go to\\n  # origin. Origin will raise the log level for such requests too. So all roung\\n  # convenience.\\n  if (beresp.http.Vary !~ \\\"X-Debug\\\") {\\n    if (beresp.http.Vary) {\\n      set beresp.http.Vary = beresp.http.Vary + \\\",X-Debug\\\";\\n    } else {\\n      set beresp.http.Vary = \\\"X-Debug\\\";\\n    }\\n  }\\n  # Vary on Strain for pipeline and static, since we're sending strain in the\\n  # backend URL.\\n  if (beresp.http.Vary !~ \\\"X-Strain\\\") {\\n    # Vary is already set above\\n    set beresp.http.Vary = beresp.http.Vary + \\\",X-Strain\\\";\\n  }\\n\\n  # Vary on Request-Type, so that static requests don't interfere with\\n  # dynamic requests: https://github.com/adobe/helix-publish/issues/45\\n  if (beresp.http.Vary !~ \\\"X-Request-Type\\\") {\\n    set beresp.http.Vary = beresp.http.Vary + \\\",X-Request-Type\\\";\\n  }\\n\\n  # TODO: Add Surrogate-Keys, based on req.url/X-Orig-URL\\n\\n  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ \\\"max-age\\\" || beresp.http.Cache-Control ~ \\\"(s-maxage|max-age)\\\") {\\n    # Use TTL from origin\\n  } else {\\n    # apply a default ttl\\n    if (beresp.status == 200) {\\n      set beresp.ttl = 604800s;\\n      set beresp.http.Cache-Control = \\\"max-age=604800, public\\\";\\n    } else {\\n      set beresp.ttl = 60s;\\n    }\\n  }\\n\\n  # checks if the request is a redirect or .hlx_xxxx request and then call helix-static respectively.\\n  call hlx_fetch_static;\\n\\n  # checks if the request is an Azure Blob\\n  call hlx_fetch_blob;\\n\\n  # checks if the request is an Algolia Query\\n  call hlx_fetch_query;\\n\\n  # check if an error response has an empty body, in this case, the dispatcher didn't deliver\\n  # a valid error page and we use the synthentic one.\\n  # todo: this logic needs to be improved. maybe with a specific response header from the action\\n  call hlx_fetch_error;\\n\\n  if (beresp.http.X-ESI == \\\"enabled\\\" || req.http.x-esi) {\\n    esi;\\n  }\\n\\n  return(deliver);\\n}\\n\\nsub vcl_hash {\\n  set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hash(\\\" req.http.host req.url \\\")\\\";\\n#FASTLY hash\\n}\\n\\nsub vcl_hit {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_hit(\\\" req.url \\\")\\\";\\n#FASTLY hit\\n\\n  if (!obj.cacheable) {\\n    return(pass);\\n  }\\n  return(deliver);\\n}\\n\\n/**\\n * Do all BackEnd REQuest changes. One sub to be called from both vcl_miss and\\n * vcl_pass, to avoid code-rot through having to update two places.\\n */\\nsub hlx_bereq {\\n  if (req.http.X-PreFetch-Miss) {\\n    set req.http.X-PreFetch-Miss = req.http.X-PreFetch-Miss + \\\"; hlx_bereq\\\";\\n  } elseif (req.http.X-PreFetch-Pass) {\\n    set req.http.X-PreFetch-Pass = req.http.X-PreFetch-Pass + \\\"; hlx_bereq\\\";\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_bereq\\\";\\n  }\\n\\n  # If we're going to a shield (another Fastly POP) use the original URL and\\n  # Host header. If not a shield, we're going to origin; set the URL and Host\\n  # header as explained at the top of this file.\\n  if (req.backend.is_shield) {\\n    set bereq.url = req.http.X-Orig-Url;\\n    set bereq.http.Host = req.http.X-Orig-Host;\\n  } else {\\n    if (req.http.X-Backend-URL) {\\n      set bereq.url = req.http.X-Backend-URL;\\n    }\\n    if (req.backend == F_AdobeRuntime) {\\n      set bereq.http.Host = \\\"adobeioruntime.net\\\";\\n    } elsif (req.backend == F_GitHub) {\\n      set bereq.http.Host = \\\"raw.githubusercontent.com\\\";\\n    } elseif (req.backend == F_AzureBlobs) {\\n      set bereq.http.Host = \\\"hlx.blob.core.windows.net\\\";\\n    } elseif (req.backend == F_Algolia) {\\n      # we are passing the APP ID through the secrets table\\n      set bereq.http.Host = table.lookup(secrets, \\\"ALGOLIA_APP_ID\\\") + \\\"-dsn.algolia.net\\\";\\n    }\\n  }\\n\\n  if (req.backend == F_AdobeRuntime) {\\n    # set Adobe Runtime backend authentication\\n    set bereq.http.Authorization = table.lookup(secrets, \\\"OPENWHISK_AUTH\\\");\\n    # pass Github Token via X-Github-Token header\\n    set bereq.http.X-Github-Token = table.lookup(secrets, \\\"GITHUB_TOKEN\\\");\\n  } elsif (req.backend == F_GitHub \\u0026\\u0026 table.lookup(secrets, \\\"GITHUB_TOKEN\\\")) {\\n    # set Github backend authentication\\n    set bereq.http.Authorization = \\\"token \\\" + table.lookup(secrets, \\\"GITHUB_TOKEN\\\");\\n  } elseif (req.backend == F_Algolia) {\\n    # set Algolia Backend authentication\\n    set bereq.http.X-Algolia-Application-Id = table.lookup(secrets, \\\"ALGOLIA_APP_ID\\\");\\n    set bereq.http.X-Algolia-API-Key = table.lookup(secrets, \\\"ALGOLIA_API_KEY\\\");\\n  }\\n\\n  # making sure to get an uncompressed object for ESI\\n  unset bereq.http.Accept-Encoding;\\n\\n  # Clean up all temporary request headers, since origins might be 3rd parties\\n  unset bereq.http.X-Orig-Url;\\n  unset bereq.http.X-Orig-Host;\\n  unset bereq.http.X-Backend-URL;\\n  unset bereq.http.X-Request-Type;\\n  unset bereq.http.X-Static-Content-Type;\\n  unset bereq.http.X-Allow;\\n  unset bereq.http.X-Deny;\\n  unset bereq.http.X-Owner;\\n  unset bereq.http.X-Index;\\n  unset bereq.http.X-Repo;\\n  unset bereq.http.X-Ref;\\n  unset bereq.http.X-Root-Path;\\n  unset bereq.http.X-Action-Root;\\n  unset bereq.http.X-Github-Static-Repo;\\n  unset bereq.http.X-Github-Static-Owner;\\n  unset bereq.http.X-Github-Static-Root;\\n  unset bereq.http.X-Github-Static-Ref;\\n}\\n\\nsub vcl_miss {\\n  set req.http.X-PreFetch-Miss = \\\"; vcl_miss(\\\" bereq.http.host bereq.url \\\")\\\";\\n#FASTLY miss\\n\\n  call hlx_set_from_edge;\\n\\n  call hlx_bereq;\\n\\n  return(fetch);\\n}\\n\\nsub vcl_pass {\\n  set req.http.X-PreFetch-Pass = \\\"; vcl_pass\\\";\\n#FASTLY pass\\n\\n  call hlx_set_from_edge;\\n\\n  call hlx_bereq;\\n\\n  return(pass);\\n}\\n\\nsub vcl_deliver {\\n  # reconstruct VCL trace from information stored in backend response headers\\n  if (resp.http.X-Trace) {\\n    set req.http.X-Trace = resp.http.X-Trace;\\n  }\\n\\n  if (fastly_info.state ~ \\\"^HITPASS\\\") {\\n    set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hit(object: uncacheable, return: pass)\\\";\\n  } elseif (fastly_info.state ~ \\\"^HIT\\\") {\\n    set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hit(\\\" req.http.host req.url \\\")\\\";\\n  } else {\\n    if (resp.http.X-PreFetch-Pass) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PreFetch-Pass;\\n    }\\n\\n    if (resp.http.X-PreFetch-Miss) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PreFetch-Miss;\\n    }\\n\\n    if (resp.http.X-PostFetch) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PostFetch;\\n    }\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_deliver\\\";\\n#FASTLY deliver\\n\\n  call hlx_headers_deliver;\\n\\n  call hlx_deliver_type;\\n\\n  # only set the strain cookie for sticky strains\\n  # and only do it for the Adobe I/O Runtime backend\\n  # Proxy strains can't be sticky, because resolution sets backend and what not,\\n  # so skipping resolution would skip that too.\\n  if (req.http.X-Strain \\u0026\\u0026 req.http.X-Sticky == \\\"true\\\"\\n      \\u0026\\u0026 req.backend == F_AdobeRuntime \\u0026\\u0026 req.http.X-Request-Type != \\\"Proxy\\\") {\\n    set resp.http.Set-Cookie = \\\"X-Strain=\\\" + req.http.X-Strain + \\\"; Secure; HttpOnly; SameSite=Strict;\\\";\\n  }\\n\\n  # remove temporary headers used to reconstruct trace information\\n  unset resp.http.X-PreFetch-Miss;\\n  unset resp.http.X-PreFetch-Pass;\\n  unset resp.http.X-PostFetch;\\n\\n  if (!req.http.X-Debug) {\\n    # Unless we are debugging, shut up chatty headers\\n    unset resp.http.Access-Control-Allow-Headers;\\n    unset resp.http.Access-Control-Allow-Methods;\\n    unset resp.http.Access-Control-Allow-Origin;\\n    unset resp.http.Perf-Br-Resp-Out;\\n    unset resp.http.Server;\\n    unset resp.http.Server-Timing;\\n    unset resp.http.Via;\\n    unset resp.http.X-Backend-Name;\\n    unset resp.http.X-Backend-URL;\\n    unset resp.http.X-Cache-Hits;\\n    unset resp.http.X-Cache;\\n    unset resp.http.X-CDN-Request-ID;\\n    unset resp.http.X-Content-Type-Options;\\n    unset resp.http.X-Content-Type;\\n    unset resp.http.X-ESI;\\n    unset resp.http.X-Fastly-Request-ID;\\n    unset resp.http.X-Frame-Options;\\n    unset resp.http.X-FullDirname;\\n    unset resp.http.X-Geo-Block-List;\\n    unset resp.http.X-GitHub-Request-Id;\\n    unset resp.http.X-GW-Cache;\\n    unset resp.http.x-openwhisk-activation-id;\\n    unset resp.http.X-Request-Id;\\n    unset resp.http.X-Served-By;\\n    unset resp.http.X-Static;\\n    unset resp.http.X-Sticky;\\n    unset resp.http.X-Strain;\\n    unset resp.http.X-Timer;\\n    unset resp.http.X-Trace;\\n    unset resp.http.X-URL;\\n    unset resp.http.x-xss-protection;\\n  } else {\\n    set resp.http.X-Trace = req.http.X-Trace;\\n  }\\n  return(deliver);\\n}\\n\\nsub vcl_error {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_error\\\";\\n#FASTLY error\\n\\n  if (obj.status == 301 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    set obj.http.Location = req.http.X-Location;\\n    synthetic \\\"Moved permanently \\u003ca href='\\\" + req.http.X-Location+ \\\"'\\u003e\\\" + req.http.X-Location + \\\"\\u003c/a\\u003e\\\";\\n    return(deliver);\\n  }\\n  # synthetic response for Static-URL: creates a plain text response with the immutable URL\\n  if (obj.status == 303 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/plain\\\";\\n    set obj.status = 200;\\n    synthetic req.http.X-Location;\\n    return(deliver);\\n  }\\n  # synthetic response for Static-302: creates a redirect to the immutable URL\\n  if (obj.status == 902 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    set obj.status = 302;\\n    set obj.http.Location = req.http.X-Location;\\n    synthetic \\\"Found: \\u003ca href='\\\" + req.http.X-Location+ \\\"'\\u003e\\\" + req.http.X-Location + \\\"\\u003c/a\\u003e\\\";\\n    return(deliver);\\n  }\\n  call hlx_error_errors;\\n}\\n\\nsub vcl_log {\\n#FASTLY log\\n}\\n\",\"deleted_at\":null,\"main\":true,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"name\":\"helix.vcl\",\"created_at\":\"2018-07-19T16:00:41Z\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "fastly-ratelimit-remaining",
+              "value": "906"
+            },
+            {
+              "name": "fastly-ratelimit-reset",
+              "value": "1579615200"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes, bytes"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish, 1.1 varnish"
+            },
+            {
+              "name": "content-length",
+              "value": "104447"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 21 Jan 2020 13:04:53 GMT"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "x-served-by",
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4055-HHN"
+            },
+            {
+              "name": "x-cache",
+              "value": "MISS, MISS"
+            },
+            {
+              "name": "x-cache-hits",
+              "value": "0, 0"
+            },
+            {
+              "name": "x-timer",
+              "value": "S1579611893.841658,VS0,VE863"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            }
+          ],
+          "headersSize": 503,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-01-21T13:04:52.731Z",
+        "time": 1189,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1189
         }
       },
       {
@@ -4593,11 +4839,11 @@
           "url": "https://api.fastly.com/service/54nWWFJicKgbdVHou26Y6a/version/247/vcl/helix.vcl/main"
         },
         "response": {
-          "bodySize": 102510,
+          "bodySize": 104447,
           "content": {
             "mimeType": "application/json",
-            "size": 102510,
-            "text": "{\"version\":247,\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"deleted_at\":null,\"name\":\"helix.vcl\",\"content\":\"#\\n# Copyright 2018 Adobe. All rights reserved.\\n# This file is licensed to you under the Apache License, Version 2.0 (the \\\"License\\\");\\n# you may not use this file except in compliance with the License. You may obtain a copy\\n# of the License at http://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software distributed under\\n# the License is distributed on an \\\"AS IS\\\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS\\n# OF ANY KIND, either express or implied. See the License for the specific language\\n# governing permissions and limitations under the License.\\n#\\n\\n\\n# About URLs and Host headers:\\n# This VCL will use the following conventions:\\n# `req.url` - The canonical URL, will be used to determine the hash of the object\\n# `req.http.X-Orig-URL` - The URL as received from the client\\n# `req.http.X-Backend-URL` - The URL as should be sent to the origin (backend)\\n#\\n# Having `req.url` be canonical, vs `X-Backend-URL` being what's sent to origin\\n# allows us to do restarts to find content on other origins, and use origin\\n# specific URLs, yet have the object stored under a single hash, meaning that\\n# a cache lookup will find the proper object on the first attempt once an\\n# object is in the cache.\\n#\\n# So `req.url` is what should be left after filtering query string parameters,\\n# doing normalizations, etc. Then `req.http.X-Backend-URL` is a transformation of\\n# that, using the origin specific rewriting, etc.\\n#\\n# Domain names are handled a bit simpler:\\n# `req.http.Host` - The canonical domain name for the site, used for the hash\\n# `req.http.X-Orig-Host` - The original domain name from the client\\n#\\n# `bereq.http.Host` will be set based on the backend used.\\n#\\n# When forwarding the request from edge POP to shield POP, the original URL and\\n# original domain name will be used.\\n\\n# VCL extension points\\ninclude \\\"extensions.vcl\\\";\\n\\n/**\\n * Check the `X-From-Edge` header, which allows us to determine whether\\n * a request is coming from a Fastly edge POP. Use this instead of `Fastly-FF`\\n * since that can be spoofed, or come from another Fastly service.\\n *\\n * This should be called from the very top of `vcl_recv`\\n */\\nsub hlx_check_from_edge {\\n  # Verify correct format\\n  if (req.http.X-From-Edge ~ \\\"^(([0-9]+),[^,]+),(0x[0-9a-f]{64})$\\\"\\n      # Verify the HMAC\\n      \\u0026\\u0026 digest.secure_is_equal(\\n           # Using existing secret, but adding it to service id\\n           # TODO: use a separate secret, because changing it can have some\\n           # gnarly effects, if you don't follow it with a purge all\\n           digest.hmac_sha256(req.service_id + table.lookup(secrets, \\\"OPENWHISK_AUTH\\\")\\n           , re.group.1), re.group.3)) {\\n    declare local var.time TIME;\\n    set var.time = std.time(re.group.2, std.integer2time(-1));\\n    # And verify the timestamp is not off by more than 2 seconds\\n    if (time.is_after(var.time, time.sub(now, 2s))\\n        \\u0026\\u0026 time.is_after(time.add(now, 2s), var.time)) {\\n      # Do nothing, the header is valid\\n      return;\\n    }\\n  }\\n  # Header isn't valid, chuck it\\n  unset req.http.X-From-Edge;\\n}\\n\\n/**\\n * Set the `X-From-Edge` header that the above sub checks.\\n *\\n * Should be called from the top of `vcl_miss`/`vcl_pass`\\n */\\nsub hlx_set_from_edge {\\n  # If it exists, it's legit, leave it alone\\n  if (!bereq.http.X-From-Edge) {\\n    declare local var.data STRING;\\n    set var.data = strftime({\\\"%s\\\"}, now) + \\\",\\\" + server.datacenter;\\n    set bereq.http.X-From-Edge =\\n      var.data + \\\",\\\" + digest.hmac_sha256(\\n        # This must match whatever key is being used\\n        req.service_id + table.lookup(secrets, \\\"OPENWHISK_AUTH\\\"), var.data);\\n  }\\n}\\n\\n/**\\n * Initial processing of request\\n * Does:\\n * - Save original URL/Host\\n * - Unset headers from client\\n * - Setup secure shielding indicator\\n */\\n\\nsub hlx_recv_init {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_recv_init\\\";\\n\\n  # This is set to true for some cases, but that is not cleared upon a restart\\n  set req.hash_always_miss = false;\\n\\n  # Execute the rest only at the very start, not after restarts\\n  if (req.restarts \\u003e 0) {\\n    return;\\n  }\\n\\n  # Check/clear X-From-Edge header\\n  call hlx_check_from_edge;\\n\\n  # Set original URL, so that we can log it afterwards.\\n  set req.http.X-Orig-URL = req.url;\\n  set req.http.X-Orig-Host = req.http.Host;\\n\\n  if (!req.http.X-Debug) {\\n    # Make sure clients can't change request flow\\n    # X-Strain is currently settable by Cookie, not worth unsetting for now\\n    unset req.http.X-Backend-URL;\\n    unset req.http.X-Dirname;\\n    unset req.http.X-Request-Type;\\n    unset req.http.X-Static-Content-Type;\\n    unset req.http.X-Sticky;\\n    # Allow through from another Fastly POP as well as from debugger\\n    if (!req.http.X-From-Edge) {\\n      unset req.http.X-CDN-Request-ID;\\n    }\\n  }\\n\\n  # Force HTTPS\\n  if (!req.http.Fastly-SSL) {\\n     error 801 \\\"Force SSL\\\";\\n  }\\n\\n  # Set a unique ID if not present\\n  if (!req.http.X-CDN-Request-ID) {\\n    set req.http.X-CDN-Request-ID = randomstr(8, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(4, \\\"0123456789abcdef\\\") + \\\"-4\\\" + randomstr(3, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(1, \\\"89ab\\\") + randomstr(3, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(12, \\\"0123456789abcdef\\\");\\n  }\\n\\n  # set X-Version initial value\\n  set req.http.X-Version = regsub(req.vcl, \\\"([^.]+)\\\\.(\\\\d+)_(\\\\d+)-(.*)\\\", \\\"\\\\2\\\");\\n\\n}\\n\\n\\n# Determines the current strain, and sets the X-Strain header\\nsub hlx_strain {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_strain\\\";\\n  # TODO: add X-Strain-Key as a random-generated, validation property\\n  if (req.http.X-Strain) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(header:\\\" + req.http.X-Strain + \\\")\\\";\\n  }\\n  # read strain from URL query string\\n  if (subfield(req.url.qs, \\\"hlx_strain\\\", \\\"\\u0026\\\")) {\\n    set req.http.X-Strain = subfield(req.url.qs, \\\"hlx_strain\\\", \\\"\\u0026\\\");\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(url)\\\";\\n  }\\n  # read strain from Cookie\\n  if (req.http.Cookie:X-Strain) {\\n    set req.http.X-Strain = req.http.Cookie:X-Strain;\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(cookie)\\\";\\n  }\\n\\n  # Sanitize user input. `urlencode` leaves alphanumeric and `-._~`\\n  set req.http.X-Strain = regsuball(urlencode(req.http.X-Strain), {\\\"%..\\\"}, \\\"_\\\");\\n\\n  # do not override strain if set in header\\n  if (!req.http.X-Strain||req.http.X-Strain==\\\"\\\") {\\n    set req.http.X-Strain = \\\"default\\\";\\n\\n    # run custom strain resolution\\n    include \\\"strains.vcl\\\";\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(resolved)\\\";\\n  }\\n\\n  # we don't need cookies for anything else, but Proxy strains might\\n  if (req.http.X-Request-Type != \\\"Proxy\\\") {\\n    unset req.http.Cookie;\\n  }\\n}\\n\\n# Gets the content whitelist for the current strain and sets the X-Allow header\\nsub hlx_allow {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_allow\\\";\\n\\n  # starting permissive – change this for a more restrictive default\\n  set req.http.X-Allow = table.lookup(strain_allow, req.http.X-Strain);\\n  if (!req.http.X-Allow) {\\n    set req.http.X-Allow = table.lookup(strain_allow, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the content blacklist for the current strain and sets the X-Deny header\\nsub hlx_deny {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deny\\\";\\n\\n  set req.http.X-Deny = table.lookup(strain_deny, req.http.X-Strain);\\n  if (!req.http.X-Deny) {\\n    set req.http.X-Deny = table.lookup(strain_deny, \\\"default\\\");\\n  }\\n}\\n\\n# Implements the content block list (to be called from vcl_recv)\\nsub hlx_block_recv {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_block_recv\\\";\\n\\n  call hlx_deny;\\n  call hlx_allow;\\n}\\n\\n# Gets the content owner for the current strain and sets the X-Owner header\\nsub hlx_owner {\\n  call hlx_owner_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_owner\\\";\\n\\n  set req.http.X-Owner = table.lookup(strain_owners, req.http.X-Strain);\\n  if (!req.http.X-Owner) {\\n    set req.http.X-Owner = table.lookup(strain_owners, \\\"default\\\");\\n  }\\n\\n  call hlx_owner_after;\\n}\\n\\n# Gets the directory index for the current strain\\nsub hlx_index {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_index\\\";\\n\\n  set req.http.X-Index = table.lookup(strain_index_files, req.http.X-Strain);\\n  if (!req.http.X-Index) {\\n    set req.http.X-Index = table.lookup(strain_index_files, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the content repo\\nsub hlx_repo {\\n  call hlx_repo_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_repo\\\";\\n  set req.http.X-Repo = table.lookup(strain_repos, req.http.X-Strain);\\n  if (!req.http.X-Repo) {\\n    set req.http.X-Repo = table.lookup(strain_repos, \\\"default\\\");\\n  }\\n\\n  call hlx_repo_after;\\n}\\n\\n# Gets the content ref\\nsub hlx_ref {\\n  call hlx_ref_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_ref\\\";\\n  set req.http.X-Ref = table.lookup(strain_refs, req.http.X-Strain);\\n  # fall back to default strain\\n  if (!req.http.X-Ref) {\\n    set req.http.X-Ref = table.lookup(strain_refs, \\\"default\\\");\\n  }\\n  # if default isn't set, use 'master'\\n  if (!req.http.X-Ref) {\\n    set req.http.X-Ref = \\\"master\\\";\\n  }\\n\\n  call hlx_ref_after;\\n}\\n\\n# Gets the content path root\\nsub hlx_root_path {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_root_path\\\";\\n  set req.http.X-Repo-Root-Path = table.lookup(strain_root_paths, req.http.X-Strain);\\n  if (!req.http.X-Repo-Root-Path) {\\n    set req.http.X-Repo-Root-Path = table.lookup(strain_root_paths, \\\"default\\\");\\n  }\\n  if (!req.http.X-Repo-Root-Path) {\\n    set req.http.X-Repo-Root-Path = \\\"\\\";\\n  }\\n}\\n\\nsub hlx_action_root {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_action_root\\\";\\n  set req.http.X-Action-Root = table.lookup(strain_action_roots, req.http.X-Strain);\\n  if (!req.http.X-Action-Root) {\\n    set req.http.X-Action-Root = table.lookup(strain_action_roots, \\\"default\\\");\\n  }\\n  #set req.http.X-Action-Root = \\\"/trieloff/default/git-github-com-adobe-helix-cli-git--dirty--\\\";\\n}\\n\\n# Gets the github static repo\\nsub hlx_github_static_repo {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_repo\\\";\\n  set req.http.X-Github-Static-Repo = table.lookup(strain_github_static_repos, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Repo) {\\n    set req.http.X-Github-Static-Repo = table.lookup(strain_github_static_repos, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the github static owner\\nsub hlx_github_static_owner {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_owner\\\";\\n  set req.http.X-Github-Static-Owner = table.lookup(strain_github_static_owners, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Owner) {\\n    set req.http.X-Github-Static-Owner = table.lookup(strain_github_static_owners, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the github static root\\nsub hlx_github_static_root {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_root\\\";\\n  set req.http.X-Github-Static-Root = table.lookup(strain_github_static_root, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Root) {\\n    set req.http.X-Github-Static-Root = table.lookup(strain_github_static_root, \\\"default\\\");\\n  }\\n  if (!req.http.X-Github-Static-Root) {\\n    set req.http.X-Github-Static-Root = \\\"/\\\";\\n  }\\n  set req.http.X-Trace = req.http.X-Trace + \\\"(\\\" + req.http.X-Github-Static-Root +  \\\")\\\";\\n}\\n\\n# Gets the github static ref\\nsub hlx_github_static_ref {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_ref\\\";\\n  set req.http.X-Github-Static-Ref = table.lookup(strain_github_static_refs, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Ref) {\\n    set req.http.X-Github-Static-Ref = table.lookup(strain_github_static_refs, \\\"default\\\");\\n  }\\n}\\n\\n# rewrite required headers (called from fetch)\\nsub hlx_headers_fetch {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_headers_fetch\\\";\\n\\n  # Add Surrogate-Key headers for soft purges\\n  if (!beresp.http.Surrogate-Key) {\\n    set beresp.http.Surrogate-Key = \\\"all\\\";\\n  } else{\\n    set beresp.http.Surrogate-Key = \\\"all \\\" + beresp.http.Surrogate-Key;\\n  }\\n\\n  # Only do this when X-Debug is present, since `Vary: X-Debug` will cause\\n  # misses, making it useless to keep this on regular objects.\\n  if (req.http.X-Debug) {\\n    if (!beresp.http.X-Backend-Name) {\\n      set beresp.http.X-Backend-Name = beresp.backend.name;\\n    }\\n    if (!beresp.http.X-CDN-Request-ID) {\\n      set beresp.http.X-CDN-Request-ID = req.http.X-CDN-Request-ID;\\n    }\\n  }\\n}\\n\\nsub hlx_headers_deliver {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_headers_deliver\\\";\\n\\n  # Set HSTS since we always do HTTPS\\n  set resp.http.Strict-Transport-Security = \\\"max-age=31536000\\\";\\n\\n  set resp.http.X-Version = req.http.X-Version;\\n\\n  if( req.http.X-Debug ) {\\n    set resp.http.X-URL = req.url;\\n    set resp.http.X-Orig-Url = req.http.X-Orig-Url;\\n    set resp.http.X-Backend-URL = req.http.X-Backend-URL;\\n    set resp.http.X-Request-Type = req.http.X-Request-Type;\\n    set resp.http.X-Strain = req.http.X-Strain;\\n    set resp.http.X-Github-Static-Ref = \\\"@\\\" + req.http.X-Github-Static-Ref;\\n\\n    set resp.http.X-Dirname = req.http.X-Dirname;\\n    set resp.http.X-FullDirname = req.http.X-FullDirname;\\n    set resp.http.X-Index = req.http.X-Index;\\n    set resp.http.X-Action-Root = req.http.X-Action-Root;\\n    set resp.http.X-Orig-URL = req.http.X-Orig-URL;\\n    set resp.http.X-Repo-Root-Path = req.http.X-Repo-Root-Path;\\n\\n    set resp.http.X-Fastly-Imageopto-Api = req.http.X-Fastly-Imageopto-Api;\\n\\n    set resp.http.X-Embed = req.http.X-Embed;\\n\\n    set resp.http.X-Trace = req.http.X-Trace;\\n }\\n\\n  call hlx_deliver_errors;\\n}\\n\\nsub hlx_determine_request_type {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_determine_request_type\\\";\\n  // TODO check for topurl\\n  if (req.url.ext == \\\"url\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(static-url)\\\";\\n    set req.http.X-Request-Type = \\\"Static-URL\\\";\\n    return;\\n  }\\n\\n  // TODO check for topurl\\n  if (req.url.ext == \\\"302\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(static-302)\\\";\\n    set req.http.X-Request-Type = \\\"Static-302\\\";\\n    return;\\n  }\\n\\n  # Exit if we already have a type\\n  if (req.http.X-Request-Type) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(existing:\\\" + req.http.X-Request-Type + \\\")\\\" ;\\n    return;\\n  }\\n\\n  // something like https://hlx.blob.core.windows.net/external/098af326aa856bb42ce9a21240cf73d6f64b0b45\\n  if (req.url ~ \\\"^(hlx_([0-9a-f]){40}).(jpg|jpeg|png|webp|gif)$\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(blob)\\\";\\n    set req.http.X-Request-Type = \\\"Blob\\\";\\n    unset req.http.Accept-Encoding;\\n    return;\\n  }\\n\\n  if (req.url.ext ~ \\\"^(hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n    set req.http.X-Request-Type = \\\"Static\\\";\\n    unset req.http.Accept-Encoding;\\n    return;\\n  }\\n\\n  if (req.http.host == \\\"adobeioruntime.net\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(embed)\\\";\\n    set req.http.X-Request-Type = \\\"Embed\\\";\\n    return;\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"(none)\\\";\\n}\\n\\n/**\\n * This subroutine implements static resource prefetching by calling Adobe I/O Runtime\\n * @header X-GitHub-Static-Owner  the owner or organization of the repo that contains the source files\\n * @header X-GitHub-Static-Repo   the repository name of the repo containing the static files\\n * @header X-GitHub-Static-Ref    the branch or tag (or commit) name to serve source files from\\n * @header X-Orig-URL             the original (unmodified) URL, starting after hostname and port\\n */\\nsub hlx_type_static_url {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_static_url\\\";\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.path STRING; # resource path\\n\\n  # Load important information from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n  # TODO: check for URL ending with `/` and look up index file\\n  set var.path = regsub(req.http.X-Orig-URL, \\\".(url|302)$\\\", \\\"\\\");\\n\\n  set req.http.X-Action-Root = \\\"/api/v1/web/\\\" + table.lookup(secrets, \\\"OPENWHISK_NAMESPACE\\\") + \\\"/helix-services/static@v1\\\";\\n  set req.http.X-Backend-URL = req.http.X-Action-Root\\n    + \\\"?owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026path=\\\" + var.path\\n    # TODO: load magic flag\\n    + \\\"\\u0026plain=true\\\"\\n    + \\\"\\u0026allow=\\\" urlencode(req.http.X-Allow)\\n    + \\\"\\u0026deny=\\\" urlencode(req.http.X-Deny)\\n    + \\\"\\u0026root=\\\" + req.http.X-Github-Static-Root;\\n}\\n\\n/**\\n * This subroutine implements static file handling by calling\\n * the hlx--static action in OpenWhisk\\n * @header X-GitHub-Static-Owner  the owner or organization of the repo that contains the source files\\n * @header X-GitHub-Static-Repo   the repository name of the repo containing the static files\\n * @header X-GitHub-Static-Ref    the branch or tag (or commit) name to serve source files from\\n * @header X-Orig-URL             the original (unmodified) URL, starting after hostname and port\\n */\\nsub hlx_type_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_static\\\";\\n  # This is a static request.\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.path STRING; # resource path\\n  declare local var.esi STRING;\\n\\n  # Load important information from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n\\n  # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441\\n  if (req.url ~ \\\"^(.*)(.hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n    # and keep only the non-hashed part, i.e. everything before .hlx_\\n    set var.path = re.group.1;\\n    set var.esi = \\\"\\u0026esi=true\\\";\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(normal)\\\";\\n    # TODO: check for URL ending with `/` and look up index file\\n    set var.path = req.url;\\n    set var.esi = \\\"\\\";\\n  }\\n  set var.path = regsuball(var.path, \\\"/+\\\", \\\"/\\\");\\n\\n  set req.http.X-Action-Root = \\\"/api/v1/web/\\\" + table.lookup(secrets, \\\"OPENWHISK_NAMESPACE\\\") + \\\"/helix-services/static@v1\\\";\\n  set req.http.X-Backend-URL = req.http.X-Action-Root\\n    + \\\"?owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026path=\\\" + var.path\\n    + var.esi\\n    # TODO: load magic flag\\n    + \\\"\\u0026plain=true\\\"\\n    + \\\"\\u0026allow=\\\" urlencode(req.http.X-Allow)\\n    + \\\"\\u0026deny=\\\" urlencode(req.http.X-Deny)\\n    + \\\"\\u0026root=\\\" + req.http.X-Github-Static-Root;\\n}\\n\\nsub hlx_type_blob {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_blob\\\";\\n  # This is a blob request.\\n\\n  # get it from Azure Blob Storage\\n  set req.backend = F_AzureBlobs;\\n\\n  declare local var.sha STRING;\\n  declare local var.ext STRING;\\n\\n  if (req.url ~ \\\"^hlx_(([0-9a-f]){40}).(jpg|jpeg|png|webp|gif)$\\\") {\\n    set var.sha = re.group.1;\\n    set var.ext = req.url.ext;\\n\\n    # TODO verify\\n    set req.http.X-Fastly-Imageopto-Api = \\\"fastly\\\";\\n  }\\n\\n  set req.http.X-Backend-URL = \\\"/external/\\\" + var.sha;\\n}\\n\\n\\n/**\\n * Handle redirect-serving for static files\\n * If the static file is too large for the hlx--static action to serve,\\n * because the payload would exceed 1 MB (OpenWhisk limit), the request\\n * is restarted, using the `X-Request-Type: Redirect` header, which means the\\n * static content will be fetched directly from GitHub, and the required\\n * response headers like Content-Type will be injected later on.\\n */\\nsub hlx_type_redirect {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_redirect\\\";\\n  # Handle a redirect from static.js by\\n  # - fetching the resource from GitHub\\n  # - don't forget to override the Content-Type header\\n  set req.backend = F_GitHub;\\n  # Replace what we have in the cache already (which is the cached redirect)\\n  set req.hash_always_miss = true;\\n}\\n\\nsub hlx_fetch_blob {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_blob\\\";\\n  if (req.http.X-Request-Type == \\\"Blob\\\" \\u0026\\u0026 beresp.status == 200) {\\n    # The URLs are a hash of the content, so we can cache stuff for a year\\n    # both on the edge and in the browser\\n    set beresp.http.Cache-Control = \\\"max-age=31622400,immutable\\\";\\n    set beresp.http.Surrogate-Control = \\\"max-age=31622400,immutable\\\";\\n    set beresp.cacheable = true;\\n    set beresp.ttl = 31622400s;\\n\\n    # TODO: should we set req.http.X-Fastly-Imageopto-Api ?\\n\\n    return(deliver);\\n  }\\n}\\n\\nsub hlx_fetch_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_static\\\";\\n  declare local var.ext STRING;\\n\\n  if (req.http.X-Request-Type == \\\"Static-URL\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(url)\\\";\\n    # Get the ETag response header and use it to construct a stable URL\\n\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n    set req.http.X-Trace = req.http.X-Trace + \\\"[url=\\\" + req.http.X-Orig-URL + \\\", ext=\\\" + var.ext + \\\"]\\\";\\n    set req.http.X-Location = regsub(req.http.X-Orig-URL, \\\".url$\\\", var.ext);\\n    error 303 \\\"URL\\\";\\n  }\\n  if (req.http.X-Request-Type == \\\"Static-302\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(302)\\\";\\n    # Get the ETag response header and use it to construct a stable URL\\n\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n    set req.http.X-Trace = req.http.X-Trace + \\\"[url=\\\" + req.http.X-Orig-URL + \\\", ext=\\\" + var.ext + \\\"]\\\";\\n    set req.http.X-Location = regsub(req.http.X-Orig-URL, \\\".302$\\\", var.ext);\\n    error 902 \\\"302\\\";\\n  }\\n  # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441\\n  if (req.http.X-Orig-URL ~ \\\"^(.*)(.hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n\\n    if (re.group.2 == var.ext) {\\n      set req.esi = true;\\n      esi;\\n      set beresp.http.X-ESI = \\\"processed(\\\" + bereq.http.Accept-Encoding + \\\", \\\" + req.esi + \\\",\\\" + req.http.X-From-Edge +\\\")\\\";\\n      set beresp.http.x-compress-hint = \\\"on\\\"; // so h2o compresses it on the way out\\n      set beresp.http.Cache-Control = \\\"max-age=31622400,immutable\\\"; # keep it for a year in the browser;\\n      set beresp.http.Surrogate-Control = \\\"max-age=31622400,immutable\\\";\\n      set beresp.cacheable = true;\\n      set beresp.ttl = 31622400s;\\n    } else {\\n      set beresp.ttl = 300s;\\n      error 404 \\\"Invalid\\\";\\n      set beresp.http.X-Trace = \\\"etag=\\\" + beresp.http.ETag + \\\"; ext=\\\" + var.ext;\\n\\n    }\\n    return(deliver);\\n  }\\n  if (beresp.http.X-Static == \\\"Raw/Static\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(raw)\\\";\\n    if (beresp.status == 307) {\\n      # Keep the redirect around for a short bit, to prevent thundering herd\\n      set beresp.cacheable = true;\\n      set beresp.ttl = 5s;\\n    }\\n    return(deliver);\\n  } elsif (req.http.X-Request-Type == \\\"Redirect\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(redirect)\\\";\\n    // and this is where we fix the headers of the GitHub static response\\n    // so that they become digestible by a browser.\\n    // - recover Content-Type from X-Content-Type\\n    // - filter out GitHub-headers\\n\\n    set beresp.http.Content-Type = req.http.X-Static-Content-Type;\\n    unset beresp.http.X-Content-Type-Options;\\n    unset beresp.http.X-Frame-Options;\\n    unset beresp.http.X-XSS-Protection;\\n    unset beresp.http.Content-Security-Policy;\\n  } elsif (beresp.status == 404 || beresp.status == 204) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(400)\\\";\\n    # Cache for a short time, restart will get rid of it anyway\\n    set beresp.ttl = 60s;\\n    return(deliver);\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(none)\\\";\\n  }\\n}\\n\\n/**\\n * Fallback handling. Depending on the previous step and the previous status code, either\\n * deliver or restart.\\n */\\nsub hlx_deliver_type {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_type(\\\" + req.http.X-Request-Type + \\\")\\\";\\n  if (req.http.X-Request-Type == \\\"Dispatch\\\") {\\n    call hlx_deliver_static;\\n  }\\n}\\n\\n/**\\n * Handle the delivery of error handlers. There are two scenarios here:\\n * 1. either the error page could be delivered from dispatch, then do nothing\\n * 2. no error page could be found, so set the correct status code and deliver a fallback\\n */\\nsub hlx_fetch_error {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_error(\\\" + beresp.status + \\\")\\\";\\n  # only use syntethic errors if not in esi sub-request and no content is delivered from the dispatcher.\\n  if (!req.http.x-topurl \\u0026\\u0026 beresp.status != 200 \\u0026\\u0026 beresp.http.Content-Length == \\\"0\\\") {\\n    # TODO: fix headers\\n    if (beresp.status == 404) {\\n       error 951 \\\"Not Found\\\";\\n    } else {\\n       error 952 \\\"Internal Server Error\\\";\\n    }\\n  }\\n  # if (req.url.basename ~ \\\"^([0-9][0-9][0-9])\\\") {\\n  #   set beresp.status = std.atoi(re.group.1);\\n  # } else {\\n  #   # this should never happen\\n  #   set beresp.status = 500;\\n  # }\\n}\\n\\n/**\\n * Handle delivery of static stuff. If there is a 404, restart with error\\n * if there is content, just deliver it. If there is a redirect, fetch\\n * from redirect and adjust headers\\n */\\nsub hlx_deliver_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_static\\\";\\n  if (resp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(ok)\\\";\\n    return;\\n  } elsif (resp.status == 307) {\\n    # perform some additional validation\\n    if (resp.http.Location ~ \\\"https://raw.githubusercontent.com(/.*)\\\") {\\n      set req.http.X-Request-Type = \\\"Redirect\\\";\\n      set req.http.X-Backend-URL = re.group.1;\\n      set req.http.X-Static-Content-Type = resp.http.X-Content-Type;\\n      set req.http.X-Trace = req.http.X-Trace + \\\"(redirect)\\\";\\n      restart;\\n    } else {\\n      set resp.status = 500;\\n      set resp.response = \\\"Redirect to wrong hostname\\\";\\n      set req.http.X-Trace = req.http.X-Trace + \\\"(redirect-error)\\\";\\n    }\\n  } else {\\n    # any other error, ignore\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(error)\\\";\\n    #set req.http.X-Request-Type = \\\"Error\\\";\\n    #set req.url = \\\"/\\\" + resp.status + \\\".html\\\"; // fall back to 500.html\\n    #restart;\\n  }\\n}\\n\\n/**\\n * Handle requests to Adobe I/O Runtime services.\\n * When Fastly handles ESI requests to 3rd-party domains, they still get routed\\n * through this service. In this method we make sure that ESI requests destined\\n * for Adobe I/O Runtime, e.g. the helix-embed service are passed through to\\n * the correct backend.\\n */\\nsub hlx_type_embed {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_embed\\\";\\n  # This is an embed request\\n  # Fastly sends embed requests back to the same service config (which is why\\n  # we are handling it here), but keeps the correct Host header in place (which\\n  # is why we can check against it)\\n  set req.backend = F_AdobeRuntime;\\n}\\n\\n\\n/**\\n * Handles requests for the main Helix rendering pipeline.\\n */\\nsub hlx_type_dispatch {\\n  call hlx_type_pipeline_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_dispatch\\\";\\n  # This is a dynamic request.\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.action STRING; # the action to call\\n  declare local var.namespace STRING;\\n  declare local var.package STRING;\\n\\n  # Load important information for content repo from edge dicts\\n  call hlx_owner;\\n  call hlx_repo;\\n  call hlx_ref;\\n  call hlx_root_path;\\n  call hlx_index;\\n\\n  # Load important information for fallback repo from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n\\n  # enable ESI\\n  # TODO: move to dispatch action\\n  set req.http.x-esi = \\\"1\\\";\\n\\n\\n  # sets X-Action-Root to something like trieloff/b7aa8a6351215b7e12b6d3be242c622410c1eb28\\n  call hlx_action_root;\\n  set var.namespace = regsuball(req.http.X-Action-Root, \\\"/.*$\\\", \\\"\\\"); // cut away the slash and everything after it\\n  set var.package = regsuball(req.http.X-Action-Root, \\\"^.*/\\\", \\\"\\\"); // cut away everything from the start up to (including) the slash\\n\\n\\n  # get (strain-specific) parameter whitelist\\n  include \\\"params.vcl\\\";\\n\\n  set req.http.X-Backend-URL = \\\"/api/v1/web\\\"\\n    + \\\"/\\\" + var.namespace // i.e. /trieloff\\n    + \\\"/helix-services/dispatch@\\\" + req.http.X-Dispatch-Version\\n    // fallback repo\\n    + \\\"?static.owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026static.repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026static.ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026static.root=\\\" + req.http.X-Github-Static-Root\\n    // content repo\\n    + \\\"\\u0026content.owner=\\\" + req.http.X-Owner\\n    + \\\"\\u0026content.repo=\\\" + req.http.X-Repo\\n    + \\\"\\u0026content.ref=\\\" + req.http.X-Ref\\n    + \\\"\\u0026content.root=\\\" + req.http.X-Repo-Root-Path\\n    + \\\"\\u0026content.package=\\\" + var.package\\n    + \\\"\\u0026content.index=\\\" + req.http.X-Index\\n    + \\\"\\u0026path=\\\" + req.url.path\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026rootPath=\\\" + req.http.X-Root-Path;\\n\\n  # only append the encoded params if there are encoded params\\n  if (req.http.X-Encoded-Params) {\\n    set req.http.X-Backend-URL = req.http.X-Backend-URL\\n      + \\\"\\u0026params=\\\" + req.http.X-Encoded-Params;\\n  }\\n\\n  call hlx_type_pipeline_after;\\n}\\n\\n/**\\n * Handle requests to Proxy Strains.\\n * These requests already have a backend set as part of the strain resolution\\n * so there is no need for URL rewriting.\\n */\\nsub hlx_type_proxy {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_proxy\\\";\\n  # TODO: set Forwarded header? (RFC7239)\\n  # TODO: Host header/URL rewrites? or all done at strain resolution time?\\n\\n  # Pass here so that `dynamic.vcl` doesn't execute for Proxy requests\\n  # And we do a pass, not a lookup, because caching third parties is way too\\n  # risky, and would take a lot of work in `vcl_fetch` to get right.\\n  return(pass);\\n}\\n\\n/**\\n  This checks X-Debug key\\n*/\\nsub hlx_check_debug_key {\\n  declare local var.debugSecret STRING;\\n  declare local var.key STRING;\\n  declare local var.level STRING;\\n\\n  set var.debugSecret = table.lookup(secrets, \\\"DEBUG_KEY\\\");\\n  set var.key = regsub(req.http.X-Debug, \\\":.*$\\\", \\\"\\\");\\n\\n  if (req.http.X-Debug ~ \\\":\\\") {\\n    set var.level = regsub(req.http.X-Debug, \\\"^.*:\\\", \\\"\\\");\\n  } else {\\n    set var.level = \\\"debug\\\";\\n  }\\n\\n  //X-Debug must be protected\\n  if (var.debugSecret \\u0026\\u0026 var.key == var.debugSecret) {\\n    set req.http.X-Debug = var.level;\\n  } else {\\n    unset req.http.X-Debug;\\n  }\\n}\\n\\n/**\\n * This is where all requests are received.\\n */\\nsub vcl_recv {\\n  if (req.restarts == 0) {\\n    if (req.http.X-Trace) {\\n      set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_recv\\\";\\n    } else {\\n      set req.http.X-Trace = \\\"vcl_recv\\\";\\n    }\\n  } else {\\n    # So we don't have to add `RESTART` to `X-Trace` whenever we use `restart`\\n    set req.http.X-Trace = req.http.X-Trace + \\\"; RESTART; vcl_recv\\\";\\n  }\\n\\n  call hlx_check_debug_key;\\n  call hlx_recv_init;\\n\\n  # run generated vcl\\n  include \\\"dynamic.vcl\\\";\\n\\n#FASTLY recv\\n\\n  # X-Location gets set by Helix's redirect logic inside the FASTLY recv block\\n  # that will get injected above.\\n  if (req.http.X-Location) {\\n    error 301 \\\"Redirect\\\";\\n  }\\n\\n  # TODO: Do we even want to set a regular origin as default? Possibly set one\\n  # that acts as a canary. If requests reach it, the VCL isn't setting a backend\\n  # somewhere.\\n  set req.backend = F_AdobeRuntime;\\n\\n  if (req.http.X-From-Edge) {\\n    # Request came from a Fastly POP, send the raw response without ESI processing\\n    set req.esi = false;\\n  } elseif ( req.url.ext == \\\"html\\\" ) {\\n    set req.http.x-esi = \\\"1\\\";\\n  }\\n\\n  # somehow we don't see the req.topurl in vcl_fetch, so we remember it here\\n  if (req.topurl) {\\n    set req.http.x-topurl = req.topurl;\\n  }\\n\\n  // compute X-FullDirname which contains the real incoming path of directories\\n  if (req.url.ext == \\\"\\\") {\\n    // case url = /a/b -\\u003e for Fastly, dirname = /a and basename = b\\n    set req.http.X-FullDirname = req.url.dirname + \\\"/\\\" + req.url.basename;\\n  } else {\\n    // case url = /a/b/c.html -\\u003e for Fastly, dirname = /a/b which is what we need\\n    set req.http.X-FullDirname = req.url.dirname;\\n  }\\n  // remove potential double slashes\\n  set req.http.X-FullDirname = regsuball(req.http.X-FullDirname, \\\"/+\\\", \\\"/\\\");\\n\\n  # Determine the current strain and execute strain-specific code\\n  call hlx_strain;\\n\\n  # block bad requests – needs current strain and unchanged req.url\\n  call hlx_block_recv;\\n\\n  # Must be after `hlx_strain`, because that might set `Proxy` as type\\n  call hlx_determine_request_type;\\n\\n  # Force clustering (despite the name of the header) to make sure we get good\\n  # cache efficiency with restarts. Without this, Fastly clustering would be\\n  # disabled after a restart, which means that each node in a Fastly POP would\\n  # use its own cache, instead of checking the designated node for the object.\\n  set req.http.Fastly-Force-Shield = \\\"yes\\\";\\n\\n  if (req.http.X-Request-Type == \\\"Proxy\\\") {\\n    call hlx_type_proxy;\\n  } elsif (req.http.X-Request-Type == \\\"Static\\\") {\\n    call hlx_type_static;\\n  } elsif (req.http.X-Request-Type == \\\"Blob\\\") {\\n    call hlx_type_blob;\\n  } elsif (req.http.X-Request-Type == \\\"Redirect\\\") {\\n    call hlx_type_redirect;\\n  } elsif (req.http.X-Request-Type == \\\"Embed\\\") {\\n    call hlx_type_embed;\\n  } elseif (req.http.X-Request-Type == \\\"Static-URL\\\") {\\n    call hlx_type_static_url;\\n  } elseif (req.http.X-Request-Type == \\\"Static-302\\\") {\\n    call hlx_type_static_url;\\n  } else {\\n    set req.http.X-Request-Type = \\\"Dispatch\\\";\\n    call hlx_type_dispatch;\\n  }\\n\\n  # re-enable shielding for changed backends\\n  # include \\\"reset.vcl\\\";\\n\\n  # We only handle GET and HEAD requests, but Proxy strains might\\n  if (req.request != \\\"HEAD\\\" \\u0026\\u0026 req.request != \\\"GET\\\" \\u0026\\u0026 req.request != \\\"FASTLYPURGE\\\") {\\n    error 405;\\n  }\\n\\n  return(lookup);\\n}\\n\\nsub hlx_fetch_errors {\\n  if (req.http.x-topurl) {\\n    # don't set syntethic error for ESI sub-requests\\n    return;\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_errors\\\";\\n  # Interpreting OpenWhisk errors is a bit tricky, because we don't have access to the JSON\\n  # of the response body. Instead we are using the Content-Length of known error messages\\n  # to determine the most likely root cause. Each root cause will get an internal status code\\n  # starting with 951, which is then handled by `hlx_error_errors` and `hlx_deliver_errors`\\n  if ( beresp.status == 404 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"74\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 951 \\\"Unknown Extension\\\";\\n  }\\n\\n  if ( beresp.status == 404 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"69\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 952 \\\"Wrong Code Path\\\";\\n  }\\n\\n  if ( beresp.status == 401 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"65\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 953 \\\"Can't Call Action\\\";\\n  }\\n}\\n\\nsub hlx_deliver_errors {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_errors\\\";\\n\\n  # Cache Condition: OpenWhisk Error Prio: 10\\n  if (resp.status == 951 ) {\\n     set resp.status = 404;\\n     set resp.response = \\\"Not Found\\\";\\n  }\\n  if (resp.status == 952 ) {\\n     set resp.status = 500;\\n     set resp.response = \\\"Internal Server Error\\\";\\n  }\\n  if (resp.status == 953 ) {\\n     set resp.status = 500;\\n     set resp.response = \\\"Internal Server Error\\\";\\n  }\\n  if (resp.status == 954) {\\n    if (req.url.basename ~ \\\"^([0-9][0-9][0-9])\\\") {\\n      set resp.status = std.atoi(re.group.1);\\n    } else {\\n      # this should never happen\\n      set resp.status = 500;\\n    }\\n  }\\n}\\n\\nsub hlx_error_errors {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_error_errors\\\";\\n  # Cache Condition: OpenWhisk Error Prio: 10\\n  if (obj.status == 951 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eResource not Found\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n\\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n\\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n\\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n\\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n\\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n\\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite;\\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6;\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e404\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eRESOURCE\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eNOT FOUND\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThe requested resource could not be found..\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\n\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 952 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n\\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n\\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n\\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n\\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n\\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n\\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite;\\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6;\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThere was an error processing your request.\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\n\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 953 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThe configured backend authentication has been rejected.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 954) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    if (req.url.basename ~ \\\"^404\\\") {\\n      synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eResource not found\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n          \\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n            \\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n            \\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n            \\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n            \\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n            \\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite; \\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6; \\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8; \\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8; \\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }    \\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e404\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eRESOURCE\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eNOT FOUND\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThe requested resource could not be found.\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\\"};\\n      return(deliver);\\n    }\\n    if (req.url.basename ~ \\\"^500\\\") {\\n      synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThere was an error processing your request.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n      return(deliver);\\n    }\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThere was an unknown error processing your request.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n    return(deliver);\\n  }\\n}\\n\\nsub vcl_fetch {\\n  # store trace information in backend response headers in order\\n  # to make them available in vcl_deliver\\n  set beresp.http.X-Trace = req.http.X-Trace;\\n  set beresp.http.X-PreFetch-Pass = req.http.X-PreFetch-Pass;\\n  set beresp.http.X-PreFetch-Miss = req.http.X-PreFetch-Miss;\\n  set beresp.http.X-PostFetch = \\\"; vcl_fetch(\\\" beresp.status \\\": \\\" req.url \\\" \\\" req.http.X-Request-Type \\\")\\\";\\n#FASTLY fetch\\n\\n  # Sprinkling in our debugging\\n  call hlx_headers_fetch;\\n\\n  # Don't try to do anything else with Proxy requests\\n  if (req.http.X-Request-Type == \\\"Proxy\\\") {\\n    return(pass);\\n  }\\n\\n  call hlx_fetch_errors;\\n\\n  unset beresp.http.Set-Cookie;\\n  unset beresp.http.Vary;\\n  unset beresp.http.Expires;\\n\\n  # We Vary on X-Debug, so that it's automatically a cache-miss, and we go to\\n  # origin. Origin will raise the log level for such requests too. So all roung\\n  # convenience.\\n  if (beresp.http.Vary !~ \\\"X-Debug\\\") {\\n    if (beresp.http.Vary) {\\n      set beresp.http.Vary = beresp.http.Vary + \\\",X-Debug\\\";\\n    } else {\\n      set beresp.http.Vary = \\\"X-Debug\\\";\\n    }\\n  }\\n  # Vary on Strain for pipeline and static, since we're sending strain in the\\n  # backend URL.\\n  if (beresp.http.Vary !~ \\\"X-Strain\\\") {\\n    # Vary is already set above\\n    set beresp.http.Vary = beresp.http.Vary + \\\",X-Strain\\\";\\n  }\\n\\n  # Vary on Request-Type, so that static requests don't interfere with\\n  # dynamic requests: https://github.com/adobe/helix-publish/issues/45\\n  if (beresp.http.Vary !~ \\\"X-Request-Type\\\") {\\n    set beresp.http.Vary = beresp.http.Vary + \\\",X-Request-Type\\\";\\n  }\\n\\n  # TODO: Add Surrogate-Keys, based on req.url/X-Orig-URL\\n\\n  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ \\\"max-age\\\" || beresp.http.Cache-Control ~ \\\"(s-maxage|max-age)\\\") {\\n    # Use TTL from origin\\n  } else {\\n    # apply a default ttl\\n    if (beresp.status == 200) {\\n      set beresp.ttl = 604800s;\\n      set beresp.http.Cache-Control = \\\"max-age=604800, public\\\";\\n    } else {\\n      set beresp.ttl = 60s;\\n    }\\n  }\\n\\n  # checks if the request is a redirect or .hlx_xxxx request and then call helix-static respectively.\\n  call hlx_fetch_static;\\n\\n  # checks if the request is an Azure Blob\\n  call hlx_fetch_blob;\\n\\n  # check if an error response has an empty body, in this case, the dispatcher didn't deliver\\n  # a valid error page and we use the synthentic one.\\n  # todo: this logic needs to be improved. maybe with a specific response header from the action\\n  call hlx_fetch_error;\\n\\n  if (beresp.http.X-ESI == \\\"enabled\\\" || req.http.x-esi) {\\n    esi;\\n  }\\n\\n  return(deliver);\\n}\\n\\nsub vcl_hash {\\n  set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hash(\\\" req.http.host req.url \\\")\\\";\\n#FASTLY hash\\n}\\n\\nsub vcl_hit {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_hit(\\\" req.url \\\")\\\";\\n#FASTLY hit\\n\\n  if (!obj.cacheable) {\\n    return(pass);\\n  }\\n  return(deliver);\\n}\\n\\n/**\\n * Do all BackEnd REQuest changes. One sub to be called from both vcl_miss and\\n * vcl_pass, to avoid code-rot through having to update two places.\\n */\\nsub hlx_bereq {\\n  if (req.http.X-PreFetch-Miss) {\\n    set req.http.X-PreFetch-Miss = req.http.X-PreFetch-Miss + \\\"; hlx_bereq\\\";\\n  } elseif (req.http.X-PreFetch-Pass) {\\n    set req.http.X-PreFetch-Pass = req.http.X-PreFetch-Pass + \\\"; hlx_bereq\\\";\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_bereq\\\";\\n  }\\n\\n  # If we're going to a shield (another Fastly POP) use the original URL and\\n  # Host header. If not a shield, we're going to origin; set the URL and Host\\n  # header as explained at the top of this file.\\n  if (req.backend.is_shield) {\\n    set bereq.url = req.http.X-Orig-Url;\\n    set bereq.http.Host = req.http.X-Orig-Host;\\n  } else {\\n    if (req.http.X-Backend-URL) {\\n      set bereq.url = req.http.X-Backend-URL;\\n    }\\n    if (req.backend == F_AdobeRuntime) {\\n      set bereq.http.Host = \\\"adobeioruntime.net\\\";\\n    } elsif (req.backend == F_GitHub) {\\n      set bereq.http.Host = \\\"raw.githubusercontent.com\\\";\\n    }\\n  }\\n\\n  if (req.backend == F_AdobeRuntime) {\\n    # set Adobe Runtime backend authentication\\n    set bereq.http.Authorization = table.lookup(secrets, \\\"OPENWHISK_AUTH\\\");\\n    # pass Github Token via X-Github-Token header\\n    set bereq.http.X-Github-Token = table.lookup(secrets, \\\"GITHUB_TOKEN\\\");\\n  } elsif (req.backend == F_GitHub \\u0026\\u0026 table.lookup(secrets, \\\"GITHUB_TOKEN\\\")) {\\n    # set Github backend authentication\\n    set bereq.http.Authorization = \\\"token \\\" + table.lookup(secrets, \\\"GITHUB_TOKEN\\\");\\n  }\\n\\n  # making sure to get an uncompressed object for ESI\\n  unset bereq.http.Accept-Encoding;\\n\\n  # Clean up all temporary request headers, since origins might be 3rd parties\\n  unset bereq.http.X-Orig-Url;\\n  unset bereq.http.X-Orig-Host;\\n  unset bereq.http.X-Backend-URL;\\n  unset bereq.http.X-Request-Type;\\n  unset bereq.http.X-Static-Content-Type;\\n  unset bereq.http.X-Allow;\\n  unset bereq.http.X-Deny;\\n  unset bereq.http.X-Owner;\\n  unset bereq.http.X-Index;\\n  unset bereq.http.X-Repo;\\n  unset bereq.http.X-Ref;\\n  unset bereq.http.X-Root-Path;\\n  unset bereq.http.X-Action-Root;\\n  unset bereq.http.X-Github-Static-Repo;\\n  unset bereq.http.X-Github-Static-Owner;\\n  unset bereq.http.X-Github-Static-Root;\\n  unset bereq.http.X-Github-Static-Ref;\\n}\\n\\nsub vcl_miss {\\n  set req.http.X-PreFetch-Miss = \\\"; vcl_miss(\\\" bereq.http.host bereq.url \\\")\\\";\\n#FASTLY miss\\n\\n  call hlx_set_from_edge;\\n\\n  call hlx_bereq;\\n\\n  return(fetch);\\n}\\n\\nsub vcl_pass {\\n  set req.http.X-PreFetch-Pass = \\\"; vcl_pass\\\";\\n#FASTLY pass\\n\\n  call hlx_set_from_edge;\\n\\n  call hlx_bereq;\\n\\n  return(pass);\\n}\\n\\nsub vcl_deliver {\\n  # reconstruct VCL trace from information stored in backend response headers\\n  if (resp.http.X-Trace) {\\n    set req.http.X-Trace = resp.http.X-Trace;\\n  }\\n\\n  if (fastly_info.state ~ \\\"^HITPASS\\\") {\\n    set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hit(object: uncacheable, return: pass)\\\";\\n  } elseif (fastly_info.state ~ \\\"^HIT\\\") {\\n    set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hit(\\\" req.http.host req.url \\\")\\\";\\n  } else {\\n    if (resp.http.X-PreFetch-Pass) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PreFetch-Pass;\\n    }\\n\\n    if (resp.http.X-PreFetch-Miss) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PreFetch-Miss;\\n    }\\n\\n    if (resp.http.X-PostFetch) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PostFetch;\\n    }\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_deliver\\\";\\n#FASTLY deliver\\n\\n  call hlx_headers_deliver;\\n\\n  call hlx_deliver_type;\\n\\n  # only set the strain cookie for sticky strains\\n  # and only do it for the Adobe I/O Runtime backend\\n  # Proxy strains can't be sticky, because resolution sets backend and what not,\\n  # so skipping resolution would skip that too.\\n  if (req.http.X-Strain \\u0026\\u0026 req.http.X-Sticky == \\\"true\\\"\\n      \\u0026\\u0026 req.backend == F_AdobeRuntime \\u0026\\u0026 req.http.X-Request-Type != \\\"Proxy\\\") {\\n    set resp.http.Set-Cookie = \\\"X-Strain=\\\" + req.http.X-Strain + \\\"; Secure; HttpOnly; SameSite=Strict;\\\";\\n  }\\n\\n  # remove temporary headers used to reconstruct trace information\\n  unset resp.http.X-PreFetch-Miss;\\n  unset resp.http.X-PreFetch-Pass;\\n  unset resp.http.X-PostFetch;\\n\\n  if (!req.http.X-Debug) {\\n    # Unless we are debugging, shut up chatty headers\\n    unset resp.http.Access-Control-Allow-Headers;\\n    unset resp.http.Access-Control-Allow-Methods;\\n    unset resp.http.Access-Control-Allow-Origin;\\n    unset resp.http.Perf-Br-Resp-Out;\\n    unset resp.http.Server;\\n    unset resp.http.Server-Timing;\\n    unset resp.http.Via;\\n    unset resp.http.X-Backend-Name;\\n    unset resp.http.X-Backend-URL;\\n    unset resp.http.X-Cache-Hits;\\n    unset resp.http.X-Cache;\\n    unset resp.http.X-CDN-Request-ID;\\n    unset resp.http.X-Content-Type-Options;\\n    unset resp.http.X-Content-Type;\\n    unset resp.http.X-ESI;\\n    unset resp.http.X-Fastly-Request-ID;\\n    unset resp.http.X-Frame-Options;\\n    unset resp.http.X-FullDirname;\\n    unset resp.http.X-Geo-Block-List;\\n    unset resp.http.X-GitHub-Request-Id;\\n    unset resp.http.X-GW-Cache;\\n    unset resp.http.x-openwhisk-activation-id;\\n    unset resp.http.X-Request-Id;\\n    unset resp.http.X-Served-By;\\n    unset resp.http.X-Static;\\n    unset resp.http.X-Sticky;\\n    unset resp.http.X-Strain;\\n    unset resp.http.X-Timer;\\n    unset resp.http.X-Trace;\\n    unset resp.http.X-URL;\\n    unset resp.http.x-xss-protection;\\n  } else {\\n    set resp.http.X-Trace = req.http.X-Trace;\\n  }\\n  return(deliver);\\n}\\n\\nsub vcl_error {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_error\\\";\\n#FASTLY error\\n\\n  if (obj.status == 301 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    set obj.http.Location = req.http.X-Location;\\n    synthetic \\\"Moved permanently \\u003ca href='\\\" + req.http.X-Location+ \\\"'\\u003e\\\" + req.http.X-Location + \\\"\\u003c/a\\u003e\\\";\\n    return(deliver);\\n  }\\n  # synthetic response for Static-URL: creates a plain text response with the immutable URL\\n  if (obj.status == 303 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/plain\\\";\\n    set obj.status = 200;\\n    synthetic req.http.X-Location;\\n    return(deliver);\\n  }\\n  # synthetic response for Static-302: creates a redirect to the immutable URL\\n  if (obj.status == 902 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    set obj.status = 302;\\n    set obj.http.Location = req.http.X-Location;\\n    synthetic \\\"Found: \\u003ca href='\\\" + req.http.X-Location+ \\\"'\\u003e\\\" + req.http.X-Location + \\\"\\u003c/a\\u003e\\\";\\n    return(deliver);\\n  }\\n  call hlx_error_errors;\\n}\\n\\nsub vcl_log {\\n#FASTLY log\\n}\\n\",\"updated_at\":\"2020-01-13T17:03:46Z\",\"main\":true,\"created_at\":\"2018-07-19T16:00:41Z\"}"
+            "size": 104447,
+            "text": "{\"name\":\"helix.vcl\",\"service_id\":\"54nWWFJicKgbdVHou26Y6a\",\"main\":true,\"created_at\":\"2018-07-19T16:00:41Z\",\"updated_at\":\"2020-01-21T13:02:10Z\",\"version\":247,\"deleted_at\":null,\"content\":\"#\\n# Copyright 2018 Adobe. All rights reserved.\\n# This file is licensed to you under the Apache License, Version 2.0 (the \\\"License\\\");\\n# you may not use this file except in compliance with the License. You may obtain a copy\\n# of the License at http://www.apache.org/licenses/LICENSE-2.0\\n#\\n# Unless required by applicable law or agreed to in writing, software distributed under\\n# the License is distributed on an \\\"AS IS\\\" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS\\n# OF ANY KIND, either express or implied. See the License for the specific language\\n# governing permissions and limitations under the License.\\n#\\n\\n\\n# About URLs and Host headers:\\n# This VCL will use the following conventions:\\n# `req.url` - The canonical URL, will be used to determine the hash of the object\\n# `req.http.X-Orig-URL` - The URL as received from the client\\n# `req.http.X-Backend-URL` - The URL as should be sent to the origin (backend)\\n#\\n# Having `req.url` be canonical, vs `X-Backend-URL` being what's sent to origin\\n# allows us to do restarts to find content on other origins, and use origin\\n# specific URLs, yet have the object stored under a single hash, meaning that\\n# a cache lookup will find the proper object on the first attempt once an\\n# object is in the cache.\\n#\\n# So `req.url` is what should be left after filtering query string parameters,\\n# doing normalizations, etc. Then `req.http.X-Backend-URL` is a transformation of\\n# that, using the origin specific rewriting, etc.\\n#\\n# Domain names are handled a bit simpler:\\n# `req.http.Host` - The canonical domain name for the site, used for the hash\\n# `req.http.X-Orig-Host` - The original domain name from the client\\n#\\n# `bereq.http.Host` will be set based on the backend used.\\n#\\n# When forwarding the request from edge POP to shield POP, the original URL and\\n# original domain name will be used.\\n\\n# VCL extension points\\ninclude \\\"extensions.vcl\\\";\\n\\n/**\\n * Check the `X-From-Edge` header, which allows us to determine whether\\n * a request is coming from a Fastly edge POP. Use this instead of `Fastly-FF`\\n * since that can be spoofed, or come from another Fastly service.\\n *\\n * This should be called from the very top of `vcl_recv`\\n */\\nsub hlx_check_from_edge {\\n  # Verify correct format\\n  if (req.http.X-From-Edge ~ \\\"^(([0-9]+),[^,]+),(0x[0-9a-f]{64})$\\\"\\n      # Verify the HMAC\\n      \\u0026\\u0026 digest.secure_is_equal(\\n           # Using existing secret, but adding it to service id\\n           # TODO: use a separate secret, because changing it can have some\\n           # gnarly effects, if you don't follow it with a purge all\\n           digest.hmac_sha256(req.service_id + table.lookup(secrets, \\\"OPENWHISK_AUTH\\\")\\n           , re.group.1), re.group.3)) {\\n    declare local var.time TIME;\\n    set var.time = std.time(re.group.2, std.integer2time(-1));\\n    # And verify the timestamp is not off by more than 2 seconds\\n    if (time.is_after(var.time, time.sub(now, 2s))\\n        \\u0026\\u0026 time.is_after(time.add(now, 2s), var.time)) {\\n      # Do nothing, the header is valid\\n      return;\\n    }\\n  }\\n  # Header isn't valid, chuck it\\n  unset req.http.X-From-Edge;\\n}\\n\\n/**\\n * Set the `X-From-Edge` header that the above sub checks.\\n *\\n * Should be called from the top of `vcl_miss`/`vcl_pass`\\n */\\nsub hlx_set_from_edge {\\n  # If it exists, it's legit, leave it alone\\n  if (!bereq.http.X-From-Edge) {\\n    declare local var.data STRING;\\n    set var.data = strftime({\\\"%s\\\"}, now) + \\\",\\\" + server.datacenter;\\n    set bereq.http.X-From-Edge =\\n      var.data + \\\",\\\" + digest.hmac_sha256(\\n        # This must match whatever key is being used\\n        req.service_id + table.lookup(secrets, \\\"OPENWHISK_AUTH\\\"), var.data);\\n  }\\n}\\n\\n/**\\n * Initial processing of request\\n * Does:\\n * - Save original URL/Host\\n * - Unset headers from client\\n * - Setup secure shielding indicator\\n */\\n\\nsub hlx_recv_init {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_recv_init\\\";\\n\\n  # This is set to true for some cases, but that is not cleared upon a restart\\n  set req.hash_always_miss = false;\\n\\n  # Execute the rest only at the very start, not after restarts\\n  if (req.restarts \\u003e 0) {\\n    return;\\n  }\\n\\n  # Check/clear X-From-Edge header\\n  call hlx_check_from_edge;\\n\\n  # Set original URL, so that we can log it afterwards.\\n  set req.http.X-Orig-URL = req.url;\\n  set req.http.X-Orig-Host = req.http.Host;\\n\\n  if (!req.http.X-Debug) {\\n    # Make sure clients can't change request flow\\n    # X-Strain is currently settable by Cookie, not worth unsetting for now\\n    unset req.http.X-Backend-URL;\\n    unset req.http.X-Dirname;\\n    unset req.http.X-Request-Type;\\n    unset req.http.X-Static-Content-Type;\\n    unset req.http.X-Sticky;\\n    # Allow through from another Fastly POP as well as from debugger\\n    if (!req.http.X-From-Edge) {\\n      unset req.http.X-CDN-Request-ID;\\n    }\\n  }\\n\\n  # Force HTTPS\\n  if (!req.http.Fastly-SSL) {\\n     error 801 \\\"Force SSL\\\";\\n  }\\n\\n  # Set a unique ID if not present\\n  if (!req.http.X-CDN-Request-ID) {\\n    set req.http.X-CDN-Request-ID = randomstr(8, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(4, \\\"0123456789abcdef\\\") + \\\"-4\\\" + randomstr(3, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(1, \\\"89ab\\\") + randomstr(3, \\\"0123456789abcdef\\\") + \\\"-\\\" + randomstr(12, \\\"0123456789abcdef\\\");\\n  }\\n\\n  # set X-Version initial value\\n  set req.http.X-Version = regsub(req.vcl, \\\"([^.]+)\\\\.(\\\\d+)_(\\\\d+)-(.*)\\\", \\\"\\\\2\\\");\\n\\n}\\n\\n\\n# Determines the current strain, and sets the X-Strain header\\nsub hlx_strain {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_strain\\\";\\n  # TODO: add X-Strain-Key as a random-generated, validation property\\n  if (req.http.X-Strain) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(header:\\\" + req.http.X-Strain + \\\")\\\";\\n  }\\n  # read strain from URL query string\\n  if (subfield(req.url.qs, \\\"hlx_strain\\\", \\\"\\u0026\\\")) {\\n    set req.http.X-Strain = subfield(req.url.qs, \\\"hlx_strain\\\", \\\"\\u0026\\\");\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(url)\\\";\\n  }\\n  # read strain from Cookie\\n  if (req.http.Cookie:X-Strain) {\\n    set req.http.X-Strain = req.http.Cookie:X-Strain;\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(cookie)\\\";\\n  }\\n\\n  # Sanitize user input. `urlencode` leaves alphanumeric and `-._~`\\n  set req.http.X-Strain = regsuball(urlencode(req.http.X-Strain), {\\\"%..\\\"}, \\\"_\\\");\\n\\n  # do not override strain if set in header\\n  if (!req.http.X-Strain||req.http.X-Strain==\\\"\\\") {\\n    set req.http.X-Strain = \\\"default\\\";\\n\\n    # run custom strain resolution\\n    include \\\"strains.vcl\\\";\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(resolved)\\\";\\n  }\\n\\n  # we don't need cookies for anything else, but Proxy strains might\\n  if (req.http.X-Request-Type != \\\"Proxy\\\") {\\n    unset req.http.Cookie;\\n  }\\n}\\n\\n# Gets the content whitelist for the current strain and sets the X-Allow header\\nsub hlx_allow {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_allow\\\";\\n\\n  # starting permissive – change this for a more restrictive default\\n  set req.http.X-Allow = table.lookup(strain_allow, req.http.X-Strain);\\n  if (!req.http.X-Allow) {\\n    set req.http.X-Allow = table.lookup(strain_allow, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the content blacklist for the current strain and sets the X-Deny header\\nsub hlx_deny {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deny\\\";\\n\\n  set req.http.X-Deny = table.lookup(strain_deny, req.http.X-Strain);\\n  if (!req.http.X-Deny) {\\n    set req.http.X-Deny = table.lookup(strain_deny, \\\"default\\\");\\n  }\\n}\\n\\n# Implements the content block list (to be called from vcl_recv)\\nsub hlx_block_recv {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_block_recv\\\";\\n\\n  call hlx_deny;\\n  call hlx_allow;\\n}\\n\\n# Gets the content owner for the current strain and sets the X-Owner header\\nsub hlx_owner {\\n  call hlx_owner_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_owner\\\";\\n\\n  set req.http.X-Owner = table.lookup(strain_owners, req.http.X-Strain);\\n  if (!req.http.X-Owner) {\\n    set req.http.X-Owner = table.lookup(strain_owners, \\\"default\\\");\\n  }\\n\\n  call hlx_owner_after;\\n}\\n\\n# Gets the directory index for the current strain\\nsub hlx_index {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_index\\\";\\n\\n  set req.http.X-Index = table.lookup(strain_index_files, req.http.X-Strain);\\n  if (!req.http.X-Index) {\\n    set req.http.X-Index = table.lookup(strain_index_files, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the content repo\\nsub hlx_repo {\\n  call hlx_repo_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_repo\\\";\\n  set req.http.X-Repo = table.lookup(strain_repos, req.http.X-Strain);\\n  if (!req.http.X-Repo) {\\n    set req.http.X-Repo = table.lookup(strain_repos, \\\"default\\\");\\n  }\\n\\n  call hlx_repo_after;\\n}\\n\\n# Gets the content ref\\nsub hlx_ref {\\n  call hlx_ref_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_ref\\\";\\n  set req.http.X-Ref = table.lookup(strain_refs, req.http.X-Strain);\\n  # fall back to default strain\\n  if (!req.http.X-Ref) {\\n    set req.http.X-Ref = table.lookup(strain_refs, \\\"default\\\");\\n  }\\n  # if default isn't set, use 'master'\\n  if (!req.http.X-Ref) {\\n    set req.http.X-Ref = \\\"master\\\";\\n  }\\n\\n  call hlx_ref_after;\\n}\\n\\n# Gets the content path root\\nsub hlx_root_path {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_root_path\\\";\\n  set req.http.X-Repo-Root-Path = table.lookup(strain_root_paths, req.http.X-Strain);\\n  if (!req.http.X-Repo-Root-Path) {\\n    set req.http.X-Repo-Root-Path = table.lookup(strain_root_paths, \\\"default\\\");\\n  }\\n  if (!req.http.X-Repo-Root-Path) {\\n    set req.http.X-Repo-Root-Path = \\\"\\\";\\n  }\\n}\\n\\nsub hlx_action_root {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_action_root\\\";\\n  set req.http.X-Action-Root = table.lookup(strain_action_roots, req.http.X-Strain);\\n  if (!req.http.X-Action-Root) {\\n    set req.http.X-Action-Root = table.lookup(strain_action_roots, \\\"default\\\");\\n  }\\n  #set req.http.X-Action-Root = \\\"/trieloff/default/git-github-com-adobe-helix-cli-git--dirty--\\\";\\n}\\n\\n# Gets the github static repo\\nsub hlx_github_static_repo {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_repo\\\";\\n  set req.http.X-Github-Static-Repo = table.lookup(strain_github_static_repos, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Repo) {\\n    set req.http.X-Github-Static-Repo = table.lookup(strain_github_static_repos, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the github static owner\\nsub hlx_github_static_owner {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_owner\\\";\\n  set req.http.X-Github-Static-Owner = table.lookup(strain_github_static_owners, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Owner) {\\n    set req.http.X-Github-Static-Owner = table.lookup(strain_github_static_owners, \\\"default\\\");\\n  }\\n}\\n\\n# Gets the github static root\\nsub hlx_github_static_root {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_root\\\";\\n  set req.http.X-Github-Static-Root = table.lookup(strain_github_static_root, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Root) {\\n    set req.http.X-Github-Static-Root = table.lookup(strain_github_static_root, \\\"default\\\");\\n  }\\n  if (!req.http.X-Github-Static-Root) {\\n    set req.http.X-Github-Static-Root = \\\"/\\\";\\n  }\\n  set req.http.X-Trace = req.http.X-Trace + \\\"(\\\" + req.http.X-Github-Static-Root +  \\\")\\\";\\n}\\n\\n# Gets the github static ref\\nsub hlx_github_static_ref {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_github_static_ref\\\";\\n  set req.http.X-Github-Static-Ref = table.lookup(strain_github_static_refs, req.http.X-Strain);\\n  if (!req.http.X-Github-Static-Ref) {\\n    set req.http.X-Github-Static-Ref = table.lookup(strain_github_static_refs, \\\"default\\\");\\n  }\\n}\\n\\n# rewrite required headers (called from fetch)\\nsub hlx_headers_fetch {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_headers_fetch\\\";\\n\\n  # Add Surrogate-Key headers for soft purges\\n  if (!beresp.http.Surrogate-Key) {\\n    set beresp.http.Surrogate-Key = \\\"all\\\";\\n  } else{\\n    set beresp.http.Surrogate-Key = \\\"all \\\" + beresp.http.Surrogate-Key;\\n  }\\n\\n  # Only do this when X-Debug is present, since `Vary: X-Debug` will cause\\n  # misses, making it useless to keep this on regular objects.\\n  if (req.http.X-Debug) {\\n    if (!beresp.http.X-Backend-Name) {\\n      set beresp.http.X-Backend-Name = beresp.backend.name;\\n    }\\n    if (!beresp.http.X-CDN-Request-ID) {\\n      set beresp.http.X-CDN-Request-ID = req.http.X-CDN-Request-ID;\\n    }\\n  }\\n}\\n\\nsub hlx_headers_deliver {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_headers_deliver\\\";\\n\\n  # Set HSTS since we always do HTTPS\\n  set resp.http.Strict-Transport-Security = \\\"max-age=31536000\\\";\\n\\n  set resp.http.X-Version = req.http.X-Version;\\n\\n  if( req.http.X-Debug ) {\\n    set resp.http.X-URL = req.url;\\n    set resp.http.X-Orig-Url = req.http.X-Orig-Url;\\n    set resp.http.X-Backend-URL = req.http.X-Backend-URL;\\n    set resp.http.X-Request-Type = req.http.X-Request-Type;\\n    set resp.http.X-Strain = req.http.X-Strain;\\n    set resp.http.X-Github-Static-Ref = \\\"@\\\" + req.http.X-Github-Static-Ref;\\n\\n    set resp.http.X-Dirname = req.http.X-Dirname;\\n    set resp.http.X-FullDirname = req.http.X-FullDirname;\\n    set resp.http.X-Index = req.http.X-Index;\\n    set resp.http.X-Action-Root = req.http.X-Action-Root;\\n    set resp.http.X-Orig-URL = req.http.X-Orig-URL;\\n    set resp.http.X-Repo-Root-Path = req.http.X-Repo-Root-Path;\\n\\n    set resp.http.X-Fastly-Imageopto-Api = req.http.X-Fastly-Imageopto-Api;\\n\\n    set resp.http.X-Embed = req.http.X-Embed;\\n\\n    set resp.http.X-Trace = req.http.X-Trace;\\n }\\n\\n  call hlx_deliver_errors;\\n}\\n\\nsub hlx_determine_request_type {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_determine_request_type\\\";\\n  // TODO check for topurl\\n  if (req.url.ext == \\\"url\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(static-url)\\\";\\n    set req.http.X-Request-Type = \\\"Static-URL\\\";\\n    return;\\n  }\\n\\n  // TODO check for topurl\\n  if (req.url.ext == \\\"302\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(static-302)\\\";\\n    set req.http.X-Request-Type = \\\"Static-302\\\";\\n    return;\\n  }\\n\\n  # Exit if we already have a type\\n  if (req.http.X-Request-Type) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(existing:\\\" + req.http.X-Request-Type + \\\")\\\" ;\\n    return;\\n  }\\n\\n  // something like https://hlx.blob.core.windows.net/external/098af326aa856bb42ce9a21240cf73d6f64b0b45\\n  if (req.url.path ~ \\\"^/(hlx_([0-9a-f]){40}).(jpg|jpeg|png|webp|gif)$\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(blob)\\\";\\n    set req.http.X-Request-Type = \\\"Blob\\\";\\n    unset req.http.Accept-Encoding;\\n    return;\\n  }\\n\\n  // something like /_query/index/name\\n  if (req.url.path ~ \\\"^/_query/.+/.+$\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(query)\\\";\\n    set req.http.X-Request-Type = \\\"Query\\\";\\n    unset req.http.Accept-Encoding;\\n    return;\\n  }\\n\\n  if (req.url.ext ~ \\\"^(hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n    set req.http.X-Request-Type = \\\"Static\\\";\\n    unset req.http.Accept-Encoding;\\n    return;\\n  }\\n\\n  if (req.http.host == \\\"adobeioruntime.net\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(embed)\\\";\\n    set req.http.X-Request-Type = \\\"Embed\\\";\\n    return;\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"(none)\\\";\\n}\\n\\n/**\\n * This subroutine implements static resource prefetching by calling Adobe I/O Runtime\\n * @header X-GitHub-Static-Owner  the owner or organization of the repo that contains the source files\\n * @header X-GitHub-Static-Repo   the repository name of the repo containing the static files\\n * @header X-GitHub-Static-Ref    the branch or tag (or commit) name to serve source files from\\n * @header X-Orig-URL             the original (unmodified) URL, starting after hostname and port\\n */\\nsub hlx_type_static_url {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_static_url\\\";\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.path STRING; # resource path\\n\\n  # Load important information from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n  # TODO: check for URL ending with `/` and look up index file\\n  set var.path = regsub(req.http.X-Orig-URL, \\\".(url|302)$\\\", \\\"\\\");\\n\\n  set req.http.X-Action-Root = \\\"/api/v1/web/\\\" + table.lookup(secrets, \\\"OPENWHISK_NAMESPACE\\\") + \\\"/helix-services/static@v1\\\";\\n  set req.http.X-Backend-URL = req.http.X-Action-Root\\n    + \\\"?owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026path=\\\" + var.path\\n    # TODO: load magic flag\\n    + \\\"\\u0026plain=true\\\"\\n    + \\\"\\u0026allow=\\\" urlencode(req.http.X-Allow)\\n    + \\\"\\u0026deny=\\\" urlencode(req.http.X-Deny)\\n    + \\\"\\u0026root=\\\" + req.http.X-Github-Static-Root;\\n}\\n\\n/**\\n * This subroutine implements static file handling by calling\\n * the hlx--static action in OpenWhisk\\n * @header X-GitHub-Static-Owner  the owner or organization of the repo that contains the source files\\n * @header X-GitHub-Static-Repo   the repository name of the repo containing the static files\\n * @header X-GitHub-Static-Ref    the branch or tag (or commit) name to serve source files from\\n * @header X-Orig-URL             the original (unmodified) URL, starting after hostname and port\\n */\\nsub hlx_type_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_static\\\";\\n  # This is a static request.\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.path STRING; # resource path\\n  declare local var.esi STRING;\\n\\n  # Load important information from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n\\n  # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441\\n  if (req.url ~ \\\"^(.*)(.hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n    # and keep only the non-hashed part, i.e. everything before .hlx_\\n    set var.path = re.group.1;\\n    set var.esi = \\\"\\u0026esi=true\\\";\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(normal)\\\";\\n    # TODO: check for URL ending with `/` and look up index file\\n    set var.path = req.url;\\n    set var.esi = \\\"\\\";\\n  }\\n  set var.path = regsuball(var.path, \\\"/+\\\", \\\"/\\\");\\n\\n  set req.http.X-Action-Root = \\\"/api/v1/web/\\\" + table.lookup(secrets, \\\"OPENWHISK_NAMESPACE\\\") + \\\"/helix-services/static@v1\\\";\\n  set req.http.X-Backend-URL = req.http.X-Action-Root\\n    + \\\"?owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026path=\\\" + var.path\\n    + var.esi\\n    # TODO: load magic flag\\n    + \\\"\\u0026plain=true\\\"\\n    + \\\"\\u0026allow=\\\" urlencode(req.http.X-Allow)\\n    + \\\"\\u0026deny=\\\" urlencode(req.http.X-Deny)\\n    + \\\"\\u0026root=\\\" + req.http.X-Github-Static-Root;\\n}\\n\\nsub hlx_type_blob {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_blob\\\";\\n  # This is a blob request.\\n\\n  # get it from Azure Blob Storage\\n  set req.backend = F_AzureBlobs;\\n\\n  declare local var.sha STRING;\\n  declare local var.ext STRING;\\n\\n  if (req.url.path ~ \\\"^/hlx_(([0-9a-f]){40}).(jpg|jpeg|png|webp|gif)$\\\") {\\n    set var.sha = re.group.1;\\n    set var.ext = req.url.ext;\\n\\n    # TODO verify\\n    set req.http.X-Fastly-Imageopto-Api = \\\"fastly\\\";\\n  }\\n\\n  set req.http.X-Backend-URL = \\\"/external/\\\" + var.sha;\\n}\\n\\nsub hlx_type_query {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_query\\\";\\n  # yes, it's a query request\\n\\n  # get it from Algolia\\n  set req.backend = F_Algolia;\\n\\n  # Load important information for content repo from edge dicts\\n  call hlx_owner;\\n  call hlx_repo;\\n\\n  # run map queries\\n  include \\\"queries.vcl\\\";\\n}\\n\\n\\n/**\\n * Handle redirect-serving for static files\\n * If the static file is too large for the hlx--static action to serve,\\n * because the payload would exceed 1 MB (OpenWhisk limit), the request\\n * is restarted, using the `X-Request-Type: Redirect` header, which means the\\n * static content will be fetched directly from GitHub, and the required\\n * response headers like Content-Type will be injected later on.\\n */\\nsub hlx_type_redirect {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_redirect\\\";\\n  # Handle a redirect from static.js by\\n  # - fetching the resource from GitHub\\n  # - don't forget to override the Content-Type header\\n  set req.backend = F_GitHub;\\n  # Replace what we have in the cache already (which is the cached redirect)\\n  set req.hash_always_miss = true;\\n}\\n\\nsub hlx_fetch_blob {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_blob\\\";\\n  if (req.http.X-Request-Type == \\\"Blob\\\" \\u0026\\u0026 beresp.status == 200) {\\n    # The URLs are a hash of the content, so we can cache stuff for a year\\n    # both on the edge and in the browser\\n    set beresp.http.Cache-Control = \\\"max-age=31622400,immutable\\\";\\n    set beresp.http.Surrogate-Control = \\\"max-age=31622400,immutable\\\";\\n    set beresp.cacheable = true;\\n    set beresp.ttl = 31622400s;\\n\\n    if (!req.http.X-Debug) {\\n      # shut up chatty headers\\n      unset beresp.http.x-ms-blob-type;\\n      unset beresp.http.x-ms-lease-state;\\n      unset beresp.http.x-ms-lease-status;\\n      unset beresp.http.x-ms-request-id;\\n      unset beresp.http.x-ms-version;\\n      unset beresp.http.Server;\\n    }\\n\\n    # TODO: should we set req.http.X-Fastly-Imageopto-Api ?\\n\\n    return(deliver);\\n  }\\n}\\n\\nsub hlx_fetch_query {\\n  if (req.http.X-Request-Type == \\\"Blob\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_query\\\";\\n\\n    # use the cache settings configured for the query\\n    set beresp.http.Surrogate-Control = req.http.X-Surrogate-Control;\\n  }\\n}\\n\\nsub hlx_fetch_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_static\\\";\\n  declare local var.ext STRING;\\n\\n  if (req.http.X-Request-Type == \\\"Static-URL\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(url)\\\";\\n    # Get the ETag response header and use it to construct a stable URL\\n\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n    set req.http.X-Trace = req.http.X-Trace + \\\"[url=\\\" + req.http.X-Orig-URL + \\\", ext=\\\" + var.ext + \\\"]\\\";\\n    set req.http.X-Location = regsub(req.http.X-Orig-URL, \\\".url$\\\", var.ext);\\n    error 303 \\\"URL\\\";\\n  }\\n  if (req.http.X-Request-Type == \\\"Static-302\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(302)\\\";\\n    # Get the ETag response header and use it to construct a stable URL\\n\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n    set req.http.X-Trace = req.http.X-Trace + \\\"[url=\\\" + req.http.X-Orig-URL + \\\", ext=\\\" + var.ext + \\\"]\\\";\\n    set req.http.X-Location = regsub(req.http.X-Orig-URL, \\\".302$\\\", var.ext);\\n    error 902 \\\"302\\\";\\n  }\\n  # check for hard-cached files like /foo.js.hlx_f7c3bc1d808e04732adf679965ccc34ca7ae3441\\n  if (req.http.X-Orig-URL ~ \\\"^(.*)(.hlx_([0-9a-f]){20,40}$)\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(immutable)\\\";\\n\\n    set var.ext = \\\".hlx_\\\" + digest.hash_sha1(beresp.http.ETag);\\n\\n    if (re.group.2 == var.ext) {\\n      set req.esi = true;\\n      esi;\\n      set beresp.http.X-ESI = \\\"processed(\\\" + bereq.http.Accept-Encoding + \\\", \\\" + req.esi + \\\",\\\" + req.http.X-From-Edge +\\\")\\\";\\n      set beresp.http.x-compress-hint = \\\"on\\\"; // so h2o compresses it on the way out\\n      set beresp.http.Cache-Control = \\\"max-age=31622400,immutable\\\"; # keep it for a year in the browser;\\n      set beresp.http.Surrogate-Control = \\\"max-age=31622400,immutable\\\";\\n      set beresp.cacheable = true;\\n      set beresp.ttl = 31622400s;\\n    } else {\\n      set beresp.ttl = 300s;\\n      error 404 \\\"Invalid\\\";\\n      set beresp.http.X-Trace = \\\"etag=\\\" + beresp.http.ETag + \\\"; ext=\\\" + var.ext;\\n\\n    }\\n    return(deliver);\\n  }\\n  if (beresp.http.X-Static == \\\"Raw/Static\\\") {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(raw)\\\";\\n    if (beresp.status == 307) {\\n      # Keep the redirect around for a short bit, to prevent thundering herd\\n      set beresp.cacheable = true;\\n      set beresp.ttl = 5s;\\n    }\\n    return(deliver);\\n  } elsif (req.http.X-Request-Type == \\\"Redirect\\\" \\u0026\\u0026 beresp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(redirect)\\\";\\n    // and this is where we fix the headers of the GitHub static response\\n    // so that they become digestible by a browser.\\n    // - recover Content-Type from X-Content-Type\\n    // - filter out GitHub-headers\\n\\n    set beresp.http.Content-Type = req.http.X-Static-Content-Type;\\n    unset beresp.http.X-Content-Type-Options;\\n    unset beresp.http.X-Frame-Options;\\n    unset beresp.http.X-XSS-Protection;\\n    unset beresp.http.Content-Security-Policy;\\n  } elsif (beresp.status == 404 || beresp.status == 204) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(400)\\\";\\n    # Cache for a short time, restart will get rid of it anyway\\n    set beresp.ttl = 60s;\\n    return(deliver);\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(none)\\\";\\n  }\\n}\\n\\n/**\\n * Fallback handling. Depending on the previous step and the previous status code, either\\n * deliver or restart.\\n */\\nsub hlx_deliver_type {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_type(\\\" + req.http.X-Request-Type + \\\")\\\";\\n  if (req.http.X-Request-Type == \\\"Dispatch\\\") {\\n    call hlx_deliver_static;\\n  }\\n}\\n\\n/**\\n * Handle the delivery of error handlers. There are two scenarios here:\\n * 1. either the error page could be delivered from dispatch, then do nothing\\n * 2. no error page could be found, so set the correct status code and deliver a fallback\\n */\\nsub hlx_fetch_error {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_error(\\\" + beresp.status + \\\")\\\";\\n  # only use syntethic errors if not in esi sub-request and no content is delivered from the dispatcher.\\n  if (!req.http.x-topurl \\u0026\\u0026 beresp.status != 200 \\u0026\\u0026 beresp.http.Content-Length == \\\"0\\\") {\\n    # TODO: fix headers\\n    if (beresp.status == 404) {\\n       error 951 \\\"Not Found\\\";\\n    } else {\\n       error 952 \\\"Internal Server Error\\\";\\n    }\\n  }\\n  # if (req.url.basename ~ \\\"^([0-9][0-9][0-9])\\\") {\\n  #   set beresp.status = std.atoi(re.group.1);\\n  # } else {\\n  #   # this should never happen\\n  #   set beresp.status = 500;\\n  # }\\n}\\n\\n/**\\n * Handle delivery of static stuff. If there is a 404, restart with error\\n * if there is content, just deliver it. If there is a redirect, fetch\\n * from redirect and adjust headers\\n */\\nsub hlx_deliver_static {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_static\\\";\\n  if (resp.status == 200) {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(ok)\\\";\\n    return;\\n  } elsif (resp.status == 307) {\\n    # perform some additional validation\\n    if (resp.http.Location ~ \\\"https://raw.githubusercontent.com(/.*)\\\") {\\n      set req.http.X-Request-Type = \\\"Redirect\\\";\\n      set req.http.X-Backend-URL = re.group.1;\\n      set req.http.X-Static-Content-Type = resp.http.X-Content-Type;\\n      set req.http.X-Trace = req.http.X-Trace + \\\"(redirect)\\\";\\n      restart;\\n    } else {\\n      set resp.status = 500;\\n      set resp.response = \\\"Redirect to wrong hostname\\\";\\n      set req.http.X-Trace = req.http.X-Trace + \\\"(redirect-error)\\\";\\n    }\\n  } else {\\n    # any other error, ignore\\n    set req.http.X-Trace = req.http.X-Trace + \\\"(error)\\\";\\n    #set req.http.X-Request-Type = \\\"Error\\\";\\n    #set req.url = \\\"/\\\" + resp.status + \\\".html\\\"; // fall back to 500.html\\n    #restart;\\n  }\\n}\\n\\n/**\\n * Handle requests to Adobe I/O Runtime services.\\n * When Fastly handles ESI requests to 3rd-party domains, they still get routed\\n * through this service. In this method we make sure that ESI requests destined\\n * for Adobe I/O Runtime, e.g. the helix-embed service are passed through to\\n * the correct backend.\\n */\\nsub hlx_type_embed {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_embed\\\";\\n  # This is an embed request\\n  # Fastly sends embed requests back to the same service config (which is why\\n  # we are handling it here), but keeps the correct Host header in place (which\\n  # is why we can check against it)\\n  set req.backend = F_AdobeRuntime;\\n}\\n\\n\\n/**\\n * Handles requests for the main Helix rendering pipeline.\\n */\\nsub hlx_type_dispatch {\\n  call hlx_type_pipeline_before;\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_dispatch\\\";\\n  # This is a dynamic request.\\n\\n  # get it from OpenWhisk\\n  set req.backend = F_AdobeRuntime;\\n\\n  # Only declare local variables for things we mean to change before putting\\n  # them into the URL\\n  declare local var.action STRING; # the action to call\\n  declare local var.namespace STRING;\\n  declare local var.package STRING;\\n\\n  # Load important information for content repo from edge dicts\\n  call hlx_owner;\\n  call hlx_repo;\\n  call hlx_ref;\\n  call hlx_root_path;\\n  call hlx_index;\\n\\n  # Load important information for fallback repo from edge dicts\\n  call hlx_github_static_owner;\\n  call hlx_github_static_repo;\\n  call hlx_github_static_ref;\\n  call hlx_github_static_root;\\n\\n\\n  # enable ESI\\n  # TODO: move to dispatch action\\n  set req.http.x-esi = \\\"1\\\";\\n\\n\\n  # sets X-Action-Root to something like trieloff/b7aa8a6351215b7e12b6d3be242c622410c1eb28\\n  call hlx_action_root;\\n  set var.namespace = regsuball(req.http.X-Action-Root, \\\"/.*$\\\", \\\"\\\"); // cut away the slash and everything after it\\n  set var.package = regsuball(req.http.X-Action-Root, \\\"^.*/\\\", \\\"\\\"); // cut away everything from the start up to (including) the slash\\n\\n\\n  # get (strain-specific) parameter whitelist\\n  include \\\"params.vcl\\\";\\n\\n  set req.http.X-Backend-URL = \\\"/api/v1/web\\\"\\n    + \\\"/\\\" + var.namespace // i.e. /trieloff\\n    + \\\"/helix-services/dispatch@\\\" + req.http.X-Dispatch-Version\\n    // fallback repo\\n    + \\\"?static.owner=\\\" + req.http.X-Github-Static-Owner\\n    + \\\"\\u0026static.repo=\\\" + req.http.X-Github-Static-Repo\\n    + \\\"\\u0026static.ref=\\\" + req.http.X-Github-Static-Ref\\n    + \\\"\\u0026static.root=\\\" + req.http.X-Github-Static-Root\\n    // content repo\\n    + \\\"\\u0026content.owner=\\\" + req.http.X-Owner\\n    + \\\"\\u0026content.repo=\\\" + req.http.X-Repo\\n    + \\\"\\u0026content.ref=\\\" + req.http.X-Ref\\n    + \\\"\\u0026content.root=\\\" + req.http.X-Repo-Root-Path\\n    + \\\"\\u0026content.package=\\\" + var.package\\n    + \\\"\\u0026content.index=\\\" + req.http.X-Index\\n    + \\\"\\u0026path=\\\" + req.url.path\\n    + \\\"\\u0026strain=\\\" + req.http.X-Strain\\n    + \\\"\\u0026rootPath=\\\" + req.http.X-Root-Path;\\n\\n  # only append the encoded params if there are encoded params\\n  if (req.http.X-Encoded-Params) {\\n    set req.http.X-Backend-URL = req.http.X-Backend-URL\\n      + \\\"\\u0026params=\\\" + req.http.X-Encoded-Params;\\n  }\\n\\n  call hlx_type_pipeline_after;\\n}\\n\\n/**\\n * Handle requests to Proxy Strains.\\n * These requests already have a backend set as part of the strain resolution\\n * so there is no need for URL rewriting.\\n */\\nsub hlx_type_proxy {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_type_proxy\\\";\\n  # TODO: set Forwarded header? (RFC7239)\\n  # TODO: Host header/URL rewrites? or all done at strain resolution time?\\n\\n  # Pass here so that `dynamic.vcl` doesn't execute for Proxy requests\\n  # And we do a pass, not a lookup, because caching third parties is way too\\n  # risky, and would take a lot of work in `vcl_fetch` to get right.\\n  return(pass);\\n}\\n\\n/**\\n  This checks X-Debug key\\n*/\\nsub hlx_check_debug_key {\\n  declare local var.debugSecret STRING;\\n  declare local var.key STRING;\\n  declare local var.level STRING;\\n\\n  set var.debugSecret = table.lookup(secrets, \\\"DEBUG_KEY\\\");\\n  set var.key = regsub(req.http.X-Debug, \\\":.*$\\\", \\\"\\\");\\n\\n  if (req.http.X-Debug ~ \\\":\\\") {\\n    set var.level = regsub(req.http.X-Debug, \\\"^.*:\\\", \\\"\\\");\\n  } else {\\n    set var.level = \\\"debug\\\";\\n  }\\n\\n  //X-Debug must be protected\\n  if (var.debugSecret \\u0026\\u0026 var.key == var.debugSecret) {\\n    set req.http.X-Debug = var.level;\\n  } else {\\n    unset req.http.X-Debug;\\n  }\\n}\\n\\n/**\\n * This is where all requests are received.\\n */\\nsub vcl_recv {\\n  if (req.restarts == 0) {\\n    if (req.http.X-Trace) {\\n      set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_recv\\\";\\n    } else {\\n      set req.http.X-Trace = \\\"vcl_recv\\\";\\n    }\\n  } else {\\n    # So we don't have to add `RESTART` to `X-Trace` whenever we use `restart`\\n    set req.http.X-Trace = req.http.X-Trace + \\\"; RESTART; vcl_recv\\\";\\n  }\\n\\n  call hlx_check_debug_key;\\n  call hlx_recv_init;\\n\\n  # run generated vcl\\n  include \\\"dynamic.vcl\\\";\\n\\n#FASTLY recv\\n\\n  # X-Location gets set by Helix's redirect logic inside the FASTLY recv block\\n  # that will get injected above.\\n  if (req.http.X-Location) {\\n    error 301 \\\"Redirect\\\";\\n  }\\n\\n  # TODO: Do we even want to set a regular origin as default? Possibly set one\\n  # that acts as a canary. If requests reach it, the VCL isn't setting a backend\\n  # somewhere.\\n  set req.backend = F_AdobeRuntime;\\n\\n  if (req.http.X-From-Edge) {\\n    # Request came from a Fastly POP, send the raw response without ESI processing\\n    set req.esi = false;\\n  } elseif ( req.url.ext == \\\"html\\\" ) {\\n    set req.http.x-esi = \\\"1\\\";\\n  }\\n\\n  # somehow we don't see the req.topurl in vcl_fetch, so we remember it here\\n  if (req.topurl) {\\n    set req.http.x-topurl = req.topurl;\\n  }\\n\\n  // compute X-FullDirname which contains the real incoming path of directories\\n  if (req.url.ext == \\\"\\\") {\\n    // case url = /a/b -\\u003e for Fastly, dirname = /a and basename = b\\n    set req.http.X-FullDirname = req.url.dirname + \\\"/\\\" + req.url.basename;\\n  } else {\\n    // case url = /a/b/c.html -\\u003e for Fastly, dirname = /a/b which is what we need\\n    set req.http.X-FullDirname = req.url.dirname;\\n  }\\n  // remove potential double slashes\\n  set req.http.X-FullDirname = regsuball(req.http.X-FullDirname, \\\"/+\\\", \\\"/\\\");\\n\\n  # Determine the current strain and execute strain-specific code\\n  call hlx_strain;\\n\\n  # block bad requests – needs current strain and unchanged req.url\\n  call hlx_block_recv;\\n\\n  # Must be after `hlx_strain`, because that might set `Proxy` as type\\n  call hlx_determine_request_type;\\n\\n  # Force clustering (despite the name of the header) to make sure we get good\\n  # cache efficiency with restarts. Without this, Fastly clustering would be\\n  # disabled after a restart, which means that each node in a Fastly POP would\\n  # use its own cache, instead of checking the designated node for the object.\\n  set req.http.Fastly-Force-Shield = \\\"yes\\\";\\n\\n  if (req.http.X-Request-Type == \\\"Proxy\\\") {\\n    call hlx_type_proxy;\\n  } elsif (req.http.X-Request-Type == \\\"Static\\\") {\\n    call hlx_type_static;\\n  } elsif (req.http.X-Request-Type == \\\"Blob\\\") {\\n    call hlx_type_blob;\\n  } elsif (req.http.X-Request-Type == \\\"Query\\\") {\\n    call hlx_type_query;\\n  } elsif (req.http.X-Request-Type == \\\"Redirect\\\") {\\n    call hlx_type_redirect;\\n  } elsif (req.http.X-Request-Type == \\\"Embed\\\") {\\n    call hlx_type_embed;\\n  } elseif (req.http.X-Request-Type == \\\"Static-URL\\\") {\\n    call hlx_type_static_url;\\n  } elseif (req.http.X-Request-Type == \\\"Static-302\\\") {\\n    call hlx_type_static_url;\\n  } else {\\n    set req.http.X-Request-Type = \\\"Dispatch\\\";\\n    call hlx_type_dispatch;\\n  }\\n\\n  # re-enable shielding for changed backends\\n  # include \\\"reset.vcl\\\";\\n\\n  # We only handle GET and HEAD requests, but Proxy strains might\\n  if (req.request != \\\"HEAD\\\" \\u0026\\u0026 req.request != \\\"GET\\\" \\u0026\\u0026 req.request != \\\"FASTLYPURGE\\\") {\\n    error 405;\\n  }\\n\\n  return(lookup);\\n}\\n\\nsub hlx_fetch_errors {\\n  if (req.http.x-topurl) {\\n    # don't set syntethic error for ESI sub-requests\\n    return;\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_fetch_errors\\\";\\n  # Interpreting OpenWhisk errors is a bit tricky, because we don't have access to the JSON\\n  # of the response body. Instead we are using the Content-Length of known error messages\\n  # to determine the most likely root cause. Each root cause will get an internal status code\\n  # starting with 951, which is then handled by `hlx_error_errors` and `hlx_deliver_errors`\\n  if ( beresp.status == 404 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"74\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 951 \\\"Unknown Extension\\\";\\n  }\\n\\n  if ( beresp.status == 404 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"69\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 952 \\\"Wrong Code Path\\\";\\n  }\\n\\n  if ( beresp.status == 401 \\u0026\\u0026 beresp.http.Content-Type==\\\"application/json\\\" \\u0026\\u0026 beresp.http.Content-Length==\\\"65\\\" ) {\\n      # ResponseObject: Unknown Extension\\n      error 953 \\\"Can't Call Action\\\";\\n  }\\n}\\n\\nsub hlx_deliver_errors {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_deliver_errors\\\";\\n\\n  # Cache Condition: OpenWhisk Error Prio: 10\\n  if (resp.status == 951 ) {\\n     set resp.status = 404;\\n     set resp.response = \\\"Not Found\\\";\\n  }\\n  if (resp.status == 952 ) {\\n     set resp.status = 500;\\n     set resp.response = \\\"Internal Server Error\\\";\\n  }\\n  if (resp.status == 953 ) {\\n     set resp.status = 500;\\n     set resp.response = \\\"Internal Server Error\\\";\\n  }\\n  if (resp.status == 954) {\\n    if (req.url.basename ~ \\\"^([0-9][0-9][0-9])\\\") {\\n      set resp.status = std.atoi(re.group.1);\\n    } else {\\n      # this should never happen\\n      set resp.status = 500;\\n    }\\n  }\\n}\\n\\nsub hlx_error_errors {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_error_errors\\\";\\n  # Cache Condition: OpenWhisk Error Prio: 10\\n  if (obj.status == 951 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eResource not Found\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n\\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n\\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n\\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n\\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n\\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n\\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite;\\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6;\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e404\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eRESOURCE\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eNOT FOUND\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThe requested resource could not be found..\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\n\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 952 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n\\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n\\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n\\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n\\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n\\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n\\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite;\\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6;\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8;\\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThere was an error processing your request.\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\n\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 953 ) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThe configured backend authentication has been rejected.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n    return(deliver);\\n  }\\n  if (obj.status == 954) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    if (req.url.basename ~ \\\"^404\\\") {\\n      synthetic {\\\"\\u003c!doctype html\\u003e\\n\\u003chtml lang=\\\"en\\\"\\u003e\\n  \\u003chead\\u003e\\n    \\u003ctitle\\u003eResource not found\\u003c/title\\u003e\\n    \\u003c!-- Required meta tags --\\u003e\\n    \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n    \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n    \\u003cstyle\\u003e\\n@import url(https://fonts.googleapis.com/css?family=opensans:500);\\nbody{\\n                background: #111155;\\n                color:#fff;\\n                font-family: 'Open Sans', sans-serif;\\n                max-height:700px;\\n                overflow: hidden;\\n            }\\n            .c{\\n                text-align: center;\\n                display: block;\\n                position: relative;\\n                width:80%;\\n                margin:100px auto;\\n            }\\n            ._404{\\n                font-size: 220px;\\n                position: relative;\\n                display: inline-block;\\n                z-index: 2;\\n                height: 250px;\\n                letter-spacing: 15px;\\n            }\\n            ._1{\\n                text-align:center;\\n                display:block;\\n                position:relative;\\n                letter-spacing: 12px;\\n                font-size: 4em;\\n                line-height: 80%;\\n                margin-top:0.2em;\\n                margin-bottom:0.2em;\\n            }\\n            ._2{\\n                text-align:center;\\n                display:block;\\n                position: relative;\\n                font-size: 20px;\\n            }\\n            .text{\\n                font-size: 70px;\\n                text-align: center;\\n                position: relative;\\n                display: inline-block;\\n                margin: 19px 0px 0px 0px;\\n                /* top: 256.301px; */\\n                z-index: 3;\\n                width: 100%;\\n                line-height: 1.2em;\\n                display: inline-block;\\n            }\\n          \\n\\n            .btn{\\n                background-color: rgb( 255, 255, 255 );\\n                position: relative;\\n                display: inline-block;\\n                width: 358px;\\n                padding: 5px;\\n                z-index: 5;\\n                font-size: 25px;\\n                margin:0 auto;\\n                color:#111155;\\n                text-decoration: none;\\n                margin-right: 10px\\n            }\\n            .right{\\n                float:right;\\n                width:60%;\\n            }\\n            \\n            hr{\\n                padding: 0;\\n                border: none;\\n                border-top: 5px solid #fff;\\n                color: #fff;\\n                text-align: center;\\n                margin: 0px auto;\\n                width: 420px;\\n                height:10px;\\n                z-index: -10;\\n            }\\n            \\n            hr:after {\\n                content: \\\"\\\\2022\\\";\\n                display: inline-block;\\n                position: relative;\\n                top: -0.75em;\\n                font-size: 2em;\\n                padding: 0 0.2em;\\n                background: #111155;\\n            }\\n            \\n            .cloud {\\n                width: 350px; height: 120px;\\n\\n                background: #FFF;\\n                background: linear-gradient(top, #FFF 100%);\\n                background: -webkit-linear-gradient(top, #FFF 100%);\\n                background: -moz-linear-gradient(top, #FFF 100%);\\n                background: -ms-linear-gradient(top, #FFF 100%);\\n                background: -o-linear-gradient(top, #FFF 100%);\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n\\n                position: absolute;\\n                margin: 120px auto 20px;\\n                z-index:-1;\\n                transition: ease 1s;\\n            }\\n\\n            .cloud:after, .cloud:before {\\n                content: '';\\n                position: absolute;\\n                background: #FFF;\\n                z-index: -1\\n            }\\n\\n            .cloud:after {\\n                width: 100px; height: 100px;\\n                top: -50px; left: 50px;\\n\\n                border-radius: 100px;\\n                -webkit-border-radius: 100px;\\n                -moz-border-radius: 100px;\\n            }\\n\\n            .cloud:before {\\n                width: 180px; height: 180px;\\n                top: -90px; right: 50px;\\n\\n                border-radius: 200px;\\n                -webkit-border-radius: 200px;\\n                -moz-border-radius: 200px;\\n            }\\n            \\n            .x1 {\\n                top:-50px;\\n                left:100px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                opacity: 0.9;\\n                -webkit-animation: moveclouds 15s linear infinite;\\n                -moz-animation: moveclouds 15s linear infinite;\\n                -o-animation: moveclouds 15s linear infinite;\\n            }\\n            \\n            .x1_5{\\n                top:-80px;\\n                left:250px;\\n                -webkit-transform: scale(0.3);\\n                -moz-transform: scale(0.3);\\n                transform: scale(0.3);\\n                -webkit-animation: moveclouds 17s linear infinite;\\n                -moz-animation: moveclouds 17s linear infinite;\\n                -o-animation: moveclouds 17s linear infinite; \\n            }\\n\\n            .x2 {\\n                left: 250px;\\n                top:30px;\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.6; \\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x3 {\\n                left: 250px; bottom: -70px;\\n\\n                -webkit-transform: scale(0.6);\\n                -moz-transform: scale(0.6);\\n                transform: scale(0.6);\\n                opacity: 0.8; \\n\\n                -webkit-animation: moveclouds 25s linear infinite;\\n                -moz-animation: moveclouds 25s linear infinite;\\n                -o-animation: moveclouds 25s linear infinite;\\n            }\\n\\n            .x4 {\\n                left: 470px; botttom: 20px;\\n\\n                -webkit-transform: scale(0.75);\\n                -moz-transform: scale(0.75);\\n                transform: scale(0.75);\\n                opacity: 0.75;\\n\\n                -webkit-animation: moveclouds 18s linear infinite;\\n                -moz-animation: moveclouds 18s linear infinite;\\n                -o-animation: moveclouds 18s linear infinite;\\n            }\\n\\n            .x5 {\\n                left: 200px; top: 300px;\\n\\n                -webkit-transform: scale(0.5);\\n                -moz-transform: scale(0.5);\\n                transform: scale(0.5);\\n                opacity: 0.8; \\n\\n                -webkit-animation: moveclouds 20s linear infinite;\\n                -moz-animation: moveclouds 20s linear infinite;\\n                -o-animation: moveclouds 20s linear infinite;\\n            }\\n\\n            @-webkit-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-moz-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }\\n            @-o-keyframes moveclouds {\\n                0% {margin-left: 1000px;}\\n                100% {margin-left: -1000px;}\\n            }    \\n    \\u003c/style\\u003e\\n  \\u003c/head\\u003e\\n  \\u003cbody\\u003e\\n    \\u003cdiv id=\\\"clouds\\\"\\u003e\\n      \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n      \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n  \\u003cdiv class='c'\\u003e\\n      \\u003cdiv class='_404'\\u003e404\\u003c/div\\u003e\\n      \\u003chr\\u003e\\n      \\u003cdiv class='_1'\\u003eRESOURCE\\u003c/div\\u003e\\n      \\u003cdiv class='_1'\\u003eNOT FOUND\\u003c/div\\u003e\\n      \\u003ccode class='btn'\\u003eThe requested resource could not be found.\\u003c/code\\u003e\\n  \\u003c/div\\u003e\\n  \\u003c/body\\u003e\\n\\u003c/html\\u003e\\\"};\\n      return(deliver);\\n    }\\n    if (req.url.basename ~ \\\"^500\\\") {\\n      synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThere was an error processing your request.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n      return(deliver);\\n    }\\n    synthetic {\\\"\\u003c!doctype html\\u003e\\n    \\u003chtml lang=\\\"en\\\"\\u003e\\n      \\u003chead\\u003e\\n        \\u003ctitle\\u003eInternal Server Error\\u003c/title\\u003e\\n        \\u003c!-- Required meta tags --\\u003e\\n        \\u003cmeta charset=\\\"utf-8\\\"\\u003e\\n        \\u003cmeta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1, shrink-to-fit=no\\\"\\u003e\\n        \\u003cstyle\\u003e\\n    @import url(https://fonts.googleapis.com/css?family=opensans:500);\\n    body{\\n                    background: #111155;\\n                    color:#fff;\\n                    font-family: 'Open Sans', sans-serif;\\n                    max-height:700px;\\n                    overflow: hidden;\\n                }\\n                .c{\\n                    text-align: center;\\n                    display: block;\\n                    position: relative;\\n                    width:80%;\\n                    margin:100px auto;\\n                }\\n                ._404{\\n                    font-size: 220px;\\n                    position: relative;\\n                    display: inline-block;\\n                    z-index: 2;\\n                    height: 250px;\\n                    letter-spacing: 15px;\\n                }\\n                ._1{\\n                    text-align:center;\\n                    display:block;\\n                    position:relative;\\n                    letter-spacing: 12px;\\n                    font-size: 4em;\\n                    line-height: 80%;\\n                    margin-top:0.2em;\\n                    margin-bottom:0.2em;\\n                }\\n                ._2{\\n                    text-align:center;\\n                    display:block;\\n                    position: relative;\\n                    font-size: 20px;\\n                }\\n                .text{\\n                    font-size: 70px;\\n                    text-align: center;\\n                    position: relative;\\n                    display: inline-block;\\n                    margin: 19px 0px 0px 0px;\\n                    /* top: 256.301px; */\\n                    z-index: 3;\\n                    width: 100%;\\n                    line-height: 1.2em;\\n                    display: inline-block;\\n                }\\n              \\n\\n                .btn{\\n                    background-color: rgb( 255, 255, 255 );\\n                    position: relative;\\n                    display: inline-block;\\n                    width: 358px;\\n                    padding: 5px;\\n                    z-index: 5;\\n                    font-size: 25px;\\n                    margin:0 auto;\\n                    color:#111155;\\n                    text-decoration: none;\\n                    margin-right: 10px\\n                }\\n                .right{\\n                    float:right;\\n                    width:60%;\\n                }\\n                \\n                hr{\\n                    padding: 0;\\n                    border: none;\\n                    border-top: 5px solid #fff;\\n                    color: #fff;\\n                    text-align: center;\\n                    margin: 0px auto;\\n                    width: 420px;\\n                    height:10px;\\n                    z-index: -10;\\n                }\\n                \\n                hr:after {\\n                    content: \\\"\\\\2022\\\";\\n                    display: inline-block;\\n                    position: relative;\\n                    top: -0.75em;\\n                    font-size: 2em;\\n                    padding: 0 0.2em;\\n                    background: #111155;\\n                }\\n                \\n                .cloud {\\n                    width: 350px; height: 120px;\\n\\n                    background: #FFF;\\n                    background: linear-gradient(top, #FFF 100%);\\n                    background: -webkit-linear-gradient(top, #FFF 100%);\\n                    background: -moz-linear-gradient(top, #FFF 100%);\\n                    background: -ms-linear-gradient(top, #FFF 100%);\\n                    background: -o-linear-gradient(top, #FFF 100%);\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n\\n                    position: absolute;\\n                    margin: 120px auto 20px;\\n                    z-index:-1;\\n                    transition: ease 1s;\\n                }\\n\\n                .cloud:after, .cloud:before {\\n                    content: '';\\n                    position: absolute;\\n                    background: #FFF;\\n                    z-index: -1\\n                }\\n\\n                .cloud:after {\\n                    width: 100px; height: 100px;\\n                    top: -50px; left: 50px;\\n\\n                    border-radius: 100px;\\n                    -webkit-border-radius: 100px;\\n                    -moz-border-radius: 100px;\\n                }\\n\\n                .cloud:before {\\n                    width: 180px; height: 180px;\\n                    top: -90px; right: 50px;\\n\\n                    border-radius: 200px;\\n                    -webkit-border-radius: 200px;\\n                    -moz-border-radius: 200px;\\n                }\\n                \\n                .x1 {\\n                    top:-50px;\\n                    left:100px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    opacity: 0.9;\\n                    -webkit-animation: moveclouds 15s linear infinite;\\n                    -moz-animation: moveclouds 15s linear infinite;\\n                    -o-animation: moveclouds 15s linear infinite;\\n                }\\n                \\n                .x1_5{\\n                    top:-80px;\\n                    left:250px;\\n                    -webkit-transform: scale(0.3);\\n                    -moz-transform: scale(0.3);\\n                    transform: scale(0.3);\\n                    -webkit-animation: moveclouds 17s linear infinite;\\n                    -moz-animation: moveclouds 17s linear infinite;\\n                    -o-animation: moveclouds 17s linear infinite; \\n                }\\n\\n                .x2 {\\n                    left: 250px;\\n                    top:30px;\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.6; \\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x3 {\\n                    left: 250px; bottom: -70px;\\n\\n                    -webkit-transform: scale(0.6);\\n                    -moz-transform: scale(0.6);\\n                    transform: scale(0.6);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 25s linear infinite;\\n                    -moz-animation: moveclouds 25s linear infinite;\\n                    -o-animation: moveclouds 25s linear infinite;\\n                }\\n\\n                .x4 {\\n                    left: 470px; botttom: 20px;\\n\\n                    -webkit-transform: scale(0.75);\\n                    -moz-transform: scale(0.75);\\n                    transform: scale(0.75);\\n                    opacity: 0.75;\\n\\n                    -webkit-animation: moveclouds 18s linear infinite;\\n                    -moz-animation: moveclouds 18s linear infinite;\\n                    -o-animation: moveclouds 18s linear infinite;\\n                }\\n\\n                .x5 {\\n                    left: 200px; top: 300px;\\n\\n                    -webkit-transform: scale(0.5);\\n                    -moz-transform: scale(0.5);\\n                    transform: scale(0.5);\\n                    opacity: 0.8; \\n\\n                    -webkit-animation: moveclouds 20s linear infinite;\\n                    -moz-animation: moveclouds 20s linear infinite;\\n                    -o-animation: moveclouds 20s linear infinite;\\n                }\\n\\n                @-webkit-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-moz-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }\\n                @-o-keyframes moveclouds {\\n                    0% {margin-left: 1000px;}\\n                    100% {margin-left: -1000px;}\\n                }    \\n        \\u003c/style\\u003e\\n      \\u003c/head\\u003e\\n      \\u003cbody\\u003e\\n        \\u003cdiv id=\\\"clouds\\\"\\u003e\\n          \\u003cdiv class=\\\"cloud x1\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x1_5\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x2\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x3\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x4\\\"\\u003e\\u003c/div\\u003e\\n          \\u003cdiv class=\\\"cloud x5\\\"\\u003e\\u003c/div\\u003e\\n      \\u003c/div\\u003e\\n      \\u003cdiv class='c'\\u003e\\n          \\u003cdiv class='_404'\\u003e500\\u003c/div\\u003e\\n          \\u003chr\\u003e\\n          \\u003cdiv class='_1'\\u003eINTERNAL\\u003c/div\\u003e\\n          \\u003cdiv class='_1'\\u003eSERVER ERROR\\u003c/div\\u003e\\n          \\u003ccode class='btn'\\u003eThere was an unknown error processing your request.\\u003c/code\\u003e\\n      \\u003c/div\\u003e\\n      \\u003c/body\\u003e\\n    \\u003c/html\\u003e\\\"};\\n    return(deliver);\\n  }\\n}\\n\\nsub vcl_fetch {\\n  # store trace information in backend response headers in order\\n  # to make them available in vcl_deliver\\n  set beresp.http.X-Trace = req.http.X-Trace;\\n  set beresp.http.X-PreFetch-Pass = req.http.X-PreFetch-Pass;\\n  set beresp.http.X-PreFetch-Miss = req.http.X-PreFetch-Miss;\\n  set beresp.http.X-PostFetch = \\\"; vcl_fetch(\\\" beresp.status \\\": \\\" req.url \\\" \\\" req.http.X-Request-Type \\\")\\\";\\n#FASTLY fetch\\n\\n  # Sprinkling in our debugging\\n  call hlx_headers_fetch;\\n\\n  # Don't try to do anything else with Proxy requests\\n  if (req.http.X-Request-Type == \\\"Proxy\\\") {\\n    return(pass);\\n  }\\n\\n  call hlx_fetch_errors;\\n\\n  unset beresp.http.Set-Cookie;\\n  unset beresp.http.Vary;\\n  unset beresp.http.Expires;\\n\\n  # We Vary on X-Debug, so that it's automatically a cache-miss, and we go to\\n  # origin. Origin will raise the log level for such requests too. So all roung\\n  # convenience.\\n  if (beresp.http.Vary !~ \\\"X-Debug\\\") {\\n    if (beresp.http.Vary) {\\n      set beresp.http.Vary = beresp.http.Vary + \\\",X-Debug\\\";\\n    } else {\\n      set beresp.http.Vary = \\\"X-Debug\\\";\\n    }\\n  }\\n  # Vary on Strain for pipeline and static, since we're sending strain in the\\n  # backend URL.\\n  if (beresp.http.Vary !~ \\\"X-Strain\\\") {\\n    # Vary is already set above\\n    set beresp.http.Vary = beresp.http.Vary + \\\",X-Strain\\\";\\n  }\\n\\n  # Vary on Request-Type, so that static requests don't interfere with\\n  # dynamic requests: https://github.com/adobe/helix-publish/issues/45\\n  if (beresp.http.Vary !~ \\\"X-Request-Type\\\") {\\n    set beresp.http.Vary = beresp.http.Vary + \\\",X-Request-Type\\\";\\n  }\\n\\n  # TODO: Add Surrogate-Keys, based on req.url/X-Orig-URL\\n\\n  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ \\\"max-age\\\" || beresp.http.Cache-Control ~ \\\"(s-maxage|max-age)\\\") {\\n    # Use TTL from origin\\n  } else {\\n    # apply a default ttl\\n    if (beresp.status == 200) {\\n      set beresp.ttl = 604800s;\\n      set beresp.http.Cache-Control = \\\"max-age=604800, public\\\";\\n    } else {\\n      set beresp.ttl = 60s;\\n    }\\n  }\\n\\n  # checks if the request is a redirect or .hlx_xxxx request and then call helix-static respectively.\\n  call hlx_fetch_static;\\n\\n  # checks if the request is an Azure Blob\\n  call hlx_fetch_blob;\\n\\n  # checks if the request is an Algolia Query\\n  call hlx_fetch_query;\\n\\n  # check if an error response has an empty body, in this case, the dispatcher didn't deliver\\n  # a valid error page and we use the synthentic one.\\n  # todo: this logic needs to be improved. maybe with a specific response header from the action\\n  call hlx_fetch_error;\\n\\n  if (beresp.http.X-ESI == \\\"enabled\\\" || req.http.x-esi) {\\n    esi;\\n  }\\n\\n  return(deliver);\\n}\\n\\nsub vcl_hash {\\n  set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hash(\\\" req.http.host req.url \\\")\\\";\\n#FASTLY hash\\n}\\n\\nsub vcl_hit {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_hit(\\\" req.url \\\")\\\";\\n#FASTLY hit\\n\\n  if (!obj.cacheable) {\\n    return(pass);\\n  }\\n  return(deliver);\\n}\\n\\n/**\\n * Do all BackEnd REQuest changes. One sub to be called from both vcl_miss and\\n * vcl_pass, to avoid code-rot through having to update two places.\\n */\\nsub hlx_bereq {\\n  if (req.http.X-PreFetch-Miss) {\\n    set req.http.X-PreFetch-Miss = req.http.X-PreFetch-Miss + \\\"; hlx_bereq\\\";\\n  } elseif (req.http.X-PreFetch-Pass) {\\n    set req.http.X-PreFetch-Pass = req.http.X-PreFetch-Pass + \\\"; hlx_bereq\\\";\\n  } else {\\n    set req.http.X-Trace = req.http.X-Trace + \\\"; hlx_bereq\\\";\\n  }\\n\\n  # If we're going to a shield (another Fastly POP) use the original URL and\\n  # Host header. If not a shield, we're going to origin; set the URL and Host\\n  # header as explained at the top of this file.\\n  if (req.backend.is_shield) {\\n    set bereq.url = req.http.X-Orig-Url;\\n    set bereq.http.Host = req.http.X-Orig-Host;\\n  } else {\\n    if (req.http.X-Backend-URL) {\\n      set bereq.url = req.http.X-Backend-URL;\\n    }\\n    if (req.backend == F_AdobeRuntime) {\\n      set bereq.http.Host = \\\"adobeioruntime.net\\\";\\n    } elsif (req.backend == F_GitHub) {\\n      set bereq.http.Host = \\\"raw.githubusercontent.com\\\";\\n    } elseif (req.backend == F_AzureBlobs) {\\n      set bereq.http.Host = \\\"hlx.blob.core.windows.net\\\";\\n    } elseif (req.backend == F_Algolia) {\\n      # we are passing the APP ID through the secrets table\\n      set bereq.http.Host = table.lookup(secrets, \\\"ALGOLIA_APP_ID\\\") + \\\"-dsn.algolia.net\\\";\\n    }\\n  }\\n\\n  if (req.backend == F_AdobeRuntime) {\\n    # set Adobe Runtime backend authentication\\n    set bereq.http.Authorization = table.lookup(secrets, \\\"OPENWHISK_AUTH\\\");\\n    # pass Github Token via X-Github-Token header\\n    set bereq.http.X-Github-Token = table.lookup(secrets, \\\"GITHUB_TOKEN\\\");\\n  } elsif (req.backend == F_GitHub \\u0026\\u0026 table.lookup(secrets, \\\"GITHUB_TOKEN\\\")) {\\n    # set Github backend authentication\\n    set bereq.http.Authorization = \\\"token \\\" + table.lookup(secrets, \\\"GITHUB_TOKEN\\\");\\n  } elseif (req.backend == F_Algolia) {\\n    # set Algolia Backend authentication\\n    set bereq.http.X-Algolia-Application-Id = table.lookup(secrets, \\\"ALGOLIA_APP_ID\\\");\\n    set bereq.http.X-Algolia-API-Key = table.lookup(secrets, \\\"ALGOLIA_API_KEY\\\");\\n  }\\n\\n  # making sure to get an uncompressed object for ESI\\n  unset bereq.http.Accept-Encoding;\\n\\n  # Clean up all temporary request headers, since origins might be 3rd parties\\n  unset bereq.http.X-Orig-Url;\\n  unset bereq.http.X-Orig-Host;\\n  unset bereq.http.X-Backend-URL;\\n  unset bereq.http.X-Request-Type;\\n  unset bereq.http.X-Static-Content-Type;\\n  unset bereq.http.X-Allow;\\n  unset bereq.http.X-Deny;\\n  unset bereq.http.X-Owner;\\n  unset bereq.http.X-Index;\\n  unset bereq.http.X-Repo;\\n  unset bereq.http.X-Ref;\\n  unset bereq.http.X-Root-Path;\\n  unset bereq.http.X-Action-Root;\\n  unset bereq.http.X-Github-Static-Repo;\\n  unset bereq.http.X-Github-Static-Owner;\\n  unset bereq.http.X-Github-Static-Root;\\n  unset bereq.http.X-Github-Static-Ref;\\n}\\n\\nsub vcl_miss {\\n  set req.http.X-PreFetch-Miss = \\\"; vcl_miss(\\\" bereq.http.host bereq.url \\\")\\\";\\n#FASTLY miss\\n\\n  call hlx_set_from_edge;\\n\\n  call hlx_bereq;\\n\\n  return(fetch);\\n}\\n\\nsub vcl_pass {\\n  set req.http.X-PreFetch-Pass = \\\"; vcl_pass\\\";\\n#FASTLY pass\\n\\n  call hlx_set_from_edge;\\n\\n  call hlx_bereq;\\n\\n  return(pass);\\n}\\n\\nsub vcl_deliver {\\n  # reconstruct VCL trace from information stored in backend response headers\\n  if (resp.http.X-Trace) {\\n    set req.http.X-Trace = resp.http.X-Trace;\\n  }\\n\\n  if (fastly_info.state ~ \\\"^HITPASS\\\") {\\n    set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hit(object: uncacheable, return: pass)\\\";\\n  } elseif (fastly_info.state ~ \\\"^HIT\\\") {\\n    set req.http.X-Trace = req.http.X-Trace \\\"; vcl_hit(\\\" req.http.host req.url \\\")\\\";\\n  } else {\\n    if (resp.http.X-PreFetch-Pass) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PreFetch-Pass;\\n    }\\n\\n    if (resp.http.X-PreFetch-Miss) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PreFetch-Miss;\\n    }\\n\\n    if (resp.http.X-PostFetch) {\\n      set req.http.X-Trace = req.http.X-Trace resp.http.X-PostFetch;\\n    }\\n  }\\n\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_deliver\\\";\\n#FASTLY deliver\\n\\n  call hlx_headers_deliver;\\n\\n  call hlx_deliver_type;\\n\\n  # only set the strain cookie for sticky strains\\n  # and only do it for the Adobe I/O Runtime backend\\n  # Proxy strains can't be sticky, because resolution sets backend and what not,\\n  # so skipping resolution would skip that too.\\n  if (req.http.X-Strain \\u0026\\u0026 req.http.X-Sticky == \\\"true\\\"\\n      \\u0026\\u0026 req.backend == F_AdobeRuntime \\u0026\\u0026 req.http.X-Request-Type != \\\"Proxy\\\") {\\n    set resp.http.Set-Cookie = \\\"X-Strain=\\\" + req.http.X-Strain + \\\"; Secure; HttpOnly; SameSite=Strict;\\\";\\n  }\\n\\n  # remove temporary headers used to reconstruct trace information\\n  unset resp.http.X-PreFetch-Miss;\\n  unset resp.http.X-PreFetch-Pass;\\n  unset resp.http.X-PostFetch;\\n\\n  if (!req.http.X-Debug) {\\n    # Unless we are debugging, shut up chatty headers\\n    unset resp.http.Access-Control-Allow-Headers;\\n    unset resp.http.Access-Control-Allow-Methods;\\n    unset resp.http.Access-Control-Allow-Origin;\\n    unset resp.http.Perf-Br-Resp-Out;\\n    unset resp.http.Server;\\n    unset resp.http.Server-Timing;\\n    unset resp.http.Via;\\n    unset resp.http.X-Backend-Name;\\n    unset resp.http.X-Backend-URL;\\n    unset resp.http.X-Cache-Hits;\\n    unset resp.http.X-Cache;\\n    unset resp.http.X-CDN-Request-ID;\\n    unset resp.http.X-Content-Type-Options;\\n    unset resp.http.X-Content-Type;\\n    unset resp.http.X-ESI;\\n    unset resp.http.X-Fastly-Request-ID;\\n    unset resp.http.X-Frame-Options;\\n    unset resp.http.X-FullDirname;\\n    unset resp.http.X-Geo-Block-List;\\n    unset resp.http.X-GitHub-Request-Id;\\n    unset resp.http.X-GW-Cache;\\n    unset resp.http.x-openwhisk-activation-id;\\n    unset resp.http.X-Request-Id;\\n    unset resp.http.X-Served-By;\\n    unset resp.http.X-Static;\\n    unset resp.http.X-Sticky;\\n    unset resp.http.X-Strain;\\n    unset resp.http.X-Timer;\\n    unset resp.http.X-Trace;\\n    unset resp.http.X-URL;\\n    unset resp.http.x-xss-protection;\\n  } else {\\n    set resp.http.X-Trace = req.http.X-Trace;\\n  }\\n  return(deliver);\\n}\\n\\nsub vcl_error {\\n  set req.http.X-Trace = req.http.X-Trace + \\\"; vcl_error\\\";\\n#FASTLY error\\n\\n  if (obj.status == 301 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    set obj.http.Location = req.http.X-Location;\\n    synthetic \\\"Moved permanently \\u003ca href='\\\" + req.http.X-Location+ \\\"'\\u003e\\\" + req.http.X-Location + \\\"\\u003c/a\\u003e\\\";\\n    return(deliver);\\n  }\\n  # synthetic response for Static-URL: creates a plain text response with the immutable URL\\n  if (obj.status == 303 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/plain\\\";\\n    set obj.status = 200;\\n    synthetic req.http.X-Location;\\n    return(deliver);\\n  }\\n  # synthetic response for Static-302: creates a redirect to the immutable URL\\n  if (obj.status == 902 \\u0026\\u0026 req.http.X-Location) {\\n    set obj.http.Content-Type = \\\"text/html\\\";\\n    set obj.status = 302;\\n    set obj.http.Location = req.http.X-Location;\\n    synthetic \\\"Found: \\u003ca href='\\\" + req.http.X-Location+ \\\"'\\u003e\\\" + req.http.X-Location + \\\"\\u003c/a\\u003e\\\";\\n    return(deliver);\\n  }\\n  call hlx_error_errors;\\n}\\n\\nsub vcl_log {\\n#FASTLY log\\n}\\n\"}"
           },
           "cookies": [],
           "headers": [
@@ -4615,11 +4861,11 @@
             },
             {
               "name": "fastly-ratelimit-remaining",
-              "value": "969"
+              "value": "904"
             },
             {
               "name": "fastly-ratelimit-reset",
-              "value": "1578938400"
+              "value": "1579615200"
             },
             {
               "name": "accept-ranges",
@@ -4631,11 +4877,11 @@
             },
             {
               "name": "content-length",
-              "value": "102510"
+              "value": "104447"
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:48 GMT"
+              "value": "Tue, 21 Jan 2020 13:04:54 GMT"
             },
             {
               "name": "connection",
@@ -4643,7 +4889,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4022-HHN"
+              "value": "cache-control-slwdc9036-CONTROL-SLWDC, cache-hhn4062-HHN"
             },
             {
               "name": "x-cache",
@@ -4655,7 +4901,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935027.429864,VS0,VE641"
+              "value": "S1579611894.977788,VS0,VE694"
             },
             {
               "name": "vary",
@@ -4672,8 +4918,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:47.362Z",
-        "time": 831,
+        "startedDateTime": "2020-01-21T13:04:53.928Z",
+        "time": 825,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4681,7 +4927,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 831
+          "wait": 825
         }
       },
       {
@@ -4712,7 +4958,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 66,
-            "text": "{\"errors\":[],\"msg\":null,\"warnings\":[],\"messages\":[],\"status\":\"ok\"}"
+            "text": "{\"errors\":[],\"msg\":null,\"messages\":[],\"warnings\":[],\"status\":\"ok\"}"
           },
           "cookies": [],
           "headers": [
@@ -4746,7 +4992,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 13 Jan 2020 17:03:56 GMT"
+              "value": "Tue, 21 Jan 2020 13:05:03 GMT"
             },
             {
               "name": "connection",
@@ -4754,7 +5000,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-control-slwdc9037-CONTROL-SLWDC, cache-hhn4056-HHN"
+              "value": "cache-control-slwdc9035-CONTROL-SLWDC, cache-hhn4041-HHN"
             },
             {
               "name": "x-cache",
@@ -4766,7 +5012,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1578935035.688664,VS0,VE1439"
+              "value": "S1579611902.769025,VS0,VE1331"
             },
             {
               "name": "vary",
@@ -4783,8 +5029,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-01-13T17:03:54.633Z",
-        "time": 1549,
+        "startedDateTime": "2020-01-21T13:05:01.708Z",
+        "time": 1425,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4792,7 +5038,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1549
+          "wait": 1425
         }
       }
     ],

--- a/test/vcl.test.js
+++ b/test/vcl.test.js
@@ -123,7 +123,7 @@ describe('Testing vcl.js', () => {
     };
 
     const indexconfig = await new IndexConfig()
-      .withConfigPath(path.resolve(__dirname, 'fixtures/empty-queries.yaml'))
+      .withConfigPath(path.resolve(__dirname, 'fixtures/no-queries.yaml'))
       .init();
 
     assert.ok(await queries(fastly, 1, indexconfig));


### PR DESCRIPTION
This PR allows us to hide Algolia queries behind the `/_query/{index}/{name}` URL and cache requests to Algolia. 

You can try by going to https://www.primordialsoup.life/_query/blog-posts/all?page=1 (this is using a clone of theblog's index)

See https://github.com/davidnuescheler/theblog/issues/44 and https://github.com/adobe/helix-index-files/issues/3

In order to be useful, we need to adjust `helix-cli` to read the Query config and send it as part of the publish request. I'll start on this as soon as this PR has been merged.