### PR TITLE
fix(package): include required schemas in deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
       "./layouts/fastly/951.html",
       "./layouts/fastly/952.html",
       "./layouts/fastly/953.html",
-      "./layouts/fastly/generic-error.html"
+      "./layouts/fastly/generic-error.html",
+      "./node_modules/@adobe/helix-shared/src/schemas/indexconfig.schema.json",
+      "./node_modules/@adobe/helix-shared/src/schemas/index.schema.json",
+      "./node_modules/@adobe/helix-shared/src/schemas/query.schema.json",
+      "./node_modules/@adobe/helix-shared/src/schemas/property.schema.json"
     ]
   },
   "repository": {


### PR DESCRIPTION
Right now, running `hlx publish` fails due to the missing schemas.
