### PR TITLE
fix(query): guard against missing algolia app id parameter

### DIFF
--- a/src/fastly/backends.js
+++ b/src/fastly/backends.js
@@ -61,21 +61,21 @@ const backends = {
 };
 async function init(fastly, version, algoliaappid) {
   // go over all defined backends and create a new one
-  const mybackends = algoliaappid ? [...Object.values(backends), {
-    hostname: `${algoliaappid}-dsn.algolia.net`,
+  const mybackends = [...Object.values(backends), {
+    hostname: `${algoliaappid || 'undefined'}-dsn.algolia.net`,
     error_threshold: 0,
     first_byte_timeout: 60000,
     weight: 100,
-    address: `${algoliaappid}-dsn.algolia.net`,
+    address: `${algoliaappid || 'undefined'}-dsn.algolia.net`,
     connect_timeout: 1000,
     name: 'Algolia',
     port: 443,
     between_bytes_timeout: 10000,
     shield: 'iad-va-us',
-    ssl_cert_hostname: `${algoliaappid}-dsn.algolia.net`,
+    ssl_cert_hostname: `${algoliaappid || 'undefined'}-dsn.algolia.net`,
     max_conn: 200,
     use_ssl: true,
-  }] : Object.values(backends);
+  }];
   return Promise.all(mybackends.map((backend) => fastly.writeBackend(
     version,
     backend.name,

--- a/test/backends.test.js
+++ b/test/backends.test.js
@@ -24,9 +24,10 @@ describe('Testing backends.js', () => {
     };
 
     assert.ok(await init(fastly, 1));
-    assert.ok(fastly.writeBackend.calledThrice);
+    assert.equal(fastly.writeBackend.callCount, 4);
     assert.ok(fastly.writeBackend.calledWith(1, 'AdobeRuntime'));
     assert.ok(fastly.writeBackend.calledWith(1, 'GitHub'));
+    assert.ok(fastly.writeBackend.calledWith(1, 'Algolia'));
   });
 
   it('#updatestrains/full', async () => {


### PR DESCRIPTION
when no algolia app id is provided, the algolia backend will be created anyway, but using `undefined-dsn.algolia.net` as the hostname

fixes #298



Thanks for contributing!
