### PR TITLE
fix(vcl): remove x-forwarded-host header when talking to Adobe Fonts

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -624,6 +624,8 @@ sub hlx_type_fonts {
 
   # remove the /hlx_fonts/ prefix again
   set req.http.X-Backend-URL = regsub(req.url, "^/hlx_fonts/", "/");
+
+  unset req.http.x-forwarded-host;
 }
 
 


### PR DESCRIPTION
this is a speculative fix for https://github.com/davidnuescheler/theblog/issues/92 – the behavior @drwilco and I are seeing is this: when requesting a font with the x-forwarded-host header, it will return a 404 – unless the same font has been requested without the header and still resides in the Adobe Fonts CDN cache. This fix always removes the header, so that no cache poisoning is possible

fix https://github.com/davidnuescheler/theblog/issues/92

