### PR TITLE
Fallback queries

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -610,6 +610,7 @@ sub hlx_type_query {
   # Load important information for content repo from edge dicts
   call hlx_owner;
   call hlx_repo;
+  call hlx_ref;
 
 
   if (req.url.path ~ "^/_query/([^/]+)\/([^/]+)$") {

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -699,6 +699,13 @@ sub hlx_fetch_blob {
 }
 
 sub hlx_fetch_query {
+  if (beresp.http.X-Static == "Raw/Query" && beresp.status == 307) {
+    set req.http.X-Trace = req.http.X-Trace + "(raw)";
+    # Keep the redirect around for a short bit, to prevent thundering herd
+    set beresp.cacheable = true;
+    set beresp.ttl = 5s; #todo increase to 600s when this works
+    return(deliver);
+  }
   if (req.http.X-Request-Type == "Query/Redirect" && beresp.status == 200) {
     set req.http.X-Trace = req.http.X-Trace + "; hlx_fetch_query(redirect)";
 


### PR DESCRIPTION
Basic idea: when the statically configured queries (see https://github.com/adobe/helix-publish/blob/master/test/fixtures/example-queries.vcl for an example document) do not match, fall back to calling https://github.com/adobe/helix-query-index (e.g. https://adobeioruntime.net/api/v1/web/helix/helix-services/query-index@v1/blog-posts/all?__hlx_owner=trieloff&__hlx_repo=helixdemo&__hlx_ref=3aea5fd4cd4d40f5f7c6ce3d74c6f20999903cd3) which will 307 redirect to a proper Algolia search URL. When our VCL sees that URL, it should just fetch and deliver *that*.