### PR TITLE
Revert "Conditions support in helix-publish"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,9 +70,9 @@
       }
     },
     "@adobe/helix-shared": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-6.0.0.tgz",
-      "integrity": "sha512-nXig1JS4AyS5AFflye6LNNobxex0ckVe51p2bi+OEiA27KLdt70vCYruFUazU+ykASbX5KbN1YQcWT5IQoaQLA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-5.3.0.tgz",
+      "integrity": "sha512-QqzK+7H2O0wDSuRdwSPbJDS336IB6DQJasLBuaRjGtdxcjonEf+vvjilBk2VNUDPO5xsemQnF1bimljPRBm7rw==",
       "requires": {
         "@adobe/helix-log": "^4.4.1",
         "ajv": "^6.10.2",
@@ -1891,16 +1891,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "bl": {
       "version": "3.0.0",
@@ -4122,13 +4112,6 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "fill-keys": {
       "version": "1.0.2",
@@ -13758,7 +13741,6 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@adobe/fastly-native-promises": "1.15.0",
     "@adobe/helix-epsagon": "1.1.3",
     "@adobe/helix-log": "4.5.1",
-    "@adobe/helix-shared": "6.0.0",
+    "@adobe/helix-shared": "5.3.0",
     "@adobe/helix-status": "7.1.2",
     "@adobe/openwhisk-action-logger": "2.1.1",
     "@adobe/openwhisk-action-utils": "4.1.0",

--- a/src/fastly/vcl-utils.js
+++ b/src/fastly/vcl-utils.js
@@ -9,6 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+const URI = require('uri-js');
 const glob = require('glob-to-regexp');
 
 function writevcl(fastly, version, content, name, main) {
@@ -32,16 +33,22 @@ function vclbody(arr = []) {
 }
 
 function conditions([strain, vcl]) {
-  if (strain.condition) {
-    const result = [strain, {
-      sticky: false,
-      condition: strain.condition.toVCL(),
-      body: [...vclbody(vcl.body),
-        strain.condition.toVCLPath((_, subpath) => `set req.http.X-Dirname = regsub(req.http.X-FullDirname, "^${subpath}", "");
-set req.http.X-Root-Path = "${subpath}";`),
-      ].filter((line) => line),
-    }];
-    return result;
+  if (strain.url) {
+    const uri = URI.parse(strain.url);
+    if (uri.path && uri.path !== '/') {
+      const pathname = uri.path.replace(/\/$/, '');
+      const body = vclbody(vcl.body);
+      body.push(`set req.http.X-Dirname = regsub(req.http.X-FullDirname, "^${pathname}", "");`);
+      body.push(`set req.http.X-Root-Path = "${pathname}";`);
+      return [strain, {
+        sticky: false,
+        condition: `req.http.Host == "${uri.host}" && (req.http.X-FullDirname ~ "^${pathname}$" || req.http.X-FullDirname ~ "^${pathname}/")`,
+        body,
+      }];
+    }
+    return [strain, {
+      condition: `req.http.Host == "${uri.host}"`,
+    }, strain];
   }
   return [strain, vcl];
 }
@@ -70,8 +77,8 @@ set req.http.host = "${strain.origin.hostname}";
 }
 
 function proxyurls([strain, vcl]) {
-  let oldpath = strain.condition ? strain.condition.toVCLPath((_, subpath) => subpath) : '';
-  oldpath = oldpath || '/';
+  const uri = URI.parse(strain.url ? strain.url : '/');
+  const oldpath = uri.path ? uri.path : '/';
 
   const newpath = (strain.origin && strain.origin.path) ? strain.origin.path : '/';
 

--- a/test/fixtures/full-resolve.vcl
+++ b/test/fixtures/full-resolve.vcl
@@ -1,10 +1,10 @@
 # This file handles the strain resolution
 set req.http.X-Root-Path = "";
-if (req.http.host == "client.project-helix.io") {
+if (req.http.Host == "client.project-helix.io") {
   set req.http.X-Sticky = "false";
   set req.http.X-Strain = "client";
 } else if (req.http.host == "pipeline.project-helix.io") {
-  set req.http.X-Sticky = "false";
+  set req.http.X-Sticky = "true";
   set req.http.X-Strain = "pipeline";
 } else if (req.http.host == "proxy.project-helix.io") {
   
@@ -30,9 +30,9 @@ if (req.http.host == "client.project-helix.io") {
   set req.backend = F_publish;
   set req.http.host = "192.168.0.1";
   
-  set req.http.X-Sticky = "false";
+  set req.http.X-Sticky = "true";
   set req.http.X-Strain = "proxy-detailed";
-} else if (req.http.host == "developer.adobe.com" && (req.http.X-FullDirname ~ "^/olddir$" || req.http.X-FullDirname ~ "^/olddir/")) {
+} else if (req.http.Host == "developer.adobe.com" && (req.http.X-FullDirname ~ "^/olddir$" || req.http.X-FullDirname ~ "^/olddir/")) {
   set req.http.X-Dirname = regsub(req.http.X-FullDirname, "^/olddir", "");
   set req.http.X-Root-Path = "/olddir";
   

--- a/test/fixtures/full.yaml
+++ b/test/fixtures/full.yaml
@@ -36,8 +36,7 @@ strains:
   client:
     code: *myrepo
     static: *myrepo
-    condition:
-      url: https://client.project-helix.io
+    url: "https://client.project-helix.io"
     sticky: false
     content:
       repo: helix-cli
@@ -50,8 +49,7 @@ strains:
 
   pipeline:
     <<: *basestrain
-    condition:
-      url.hostname=: pipeline.project-helix.io
+    condition: req.http.host == "pipeline.project-helix.io"
     content:
       repo: hypermedia-pipeline
       ref: master
@@ -62,16 +60,14 @@ strains:
 
   proxy:
     origin: https://www.adobe.io/
-    condition: 
-      url.hostname=: proxy.project-helix.io
+    condition: req.http.host == "proxy.project-helix.io"
     sticky: true
     params:
       - "search*"
       - "*lang"
 
   proxy-detailed:
-    condition:
-      url.hostname=: proxy2.project-helix.io
+    condition: req.http.host == "proxy2.project-helix.io"
     origin:
       address: 192.168.0.1
       name: publish
@@ -79,5 +75,4 @@ strains:
 
   proxy-path:
     origin: https://www.adobe.io/newdir
-    condition:
-      url: https://developer.adobe.com/olddir
+    url: https://developer.adobe.com/olddir

--- a/test/fixtures/urls-resolve.vcl
+++ b/test/fixtures/urls-resolve.vcl
@@ -1,20 +1,20 @@
 # This file handles the strain resolution
 set req.http.X-Root-Path = "";
-if (req.http.host == "www.project-helix.io" && (req.http.X-FullDirname ~ "^/client$" || req.http.X-FullDirname ~ "^/client/")) {
+if (req.http.Host == "www.project-helix.io" && (req.http.X-FullDirname ~ "^/client$" || req.http.X-FullDirname ~ "^/client/")) {
   set req.http.X-Dirname = regsub(req.http.X-FullDirname, "^/client", "");
   set req.http.X-Root-Path = "/client";
   # Rewrite the URL to include the proxy path
   set req.url = regsub(req.url, "^/client", "/");
   set req.http.X-Sticky = "false";
   set req.http.X-Strain = "client";
-} else if (req.http.host == "www.project-helix.io" && (req.http.X-FullDirname ~ "^/pipeline$" || req.http.X-FullDirname ~ "^/pipeline/")) {
+} else if (req.http.Host == "www.project-helix.io" && (req.http.X-FullDirname ~ "^/pipeline$" || req.http.X-FullDirname ~ "^/pipeline/")) {
   set req.http.X-Dirname = regsub(req.http.X-FullDirname, "^/pipeline", "");
   set req.http.X-Root-Path = "/pipeline";
   # Rewrite the URL to include the proxy path
   set req.url = regsub(req.url, "^/pipeline", "/");
   set req.http.X-Sticky = "false";
   set req.http.X-Strain = "pipeline";
-} else if (req.http.host == "proxy.project-helix.io") {
+} else if (req.http.Host == "proxy.project-helix.io") {
   
   # Enable passing through of requests
   

--- a/test/fixtures/urls.yaml
+++ b/test/fixtures/urls.yaml
@@ -32,8 +32,7 @@ strains:
     code: *myrepo
     static: *myrepo
     sticky: false
-    condition:
-      url: https://www.project-helix.io/client
+    url: https://www.project-helix.io/client
     content:
       repo: helix-cli
       ref: master
@@ -42,8 +41,7 @@ strains:
 
   pipeline:
     <<: *basestrain
-    condition:
-      url: https://www.project-helix.io/pipeline
+    url: https://www.project-helix.io/pipeline
     content:
       repo: hypermedia-pipeline
       ref: master
@@ -53,8 +51,7 @@ strains:
       path: /www
 
   proxy:
-    condition:
-      url: https://proxy.project-helix.io/
+    url: https://proxy.project-helix.io/
     origin: https://www.adobe.io/
     sticky: true
     params:


### PR DESCRIPTION
adobe/helix-publish#332 has been merged by squashing, which means no release has been triggered. The release itself should have been a major release, as support for text-based conditions has been dropped (breaking changes).

This PR reverts the squashed merge, so that I can create a proper merge.

/cc @dominique-pfister 