### PR TITLE
fix(http): report timeouts and reduce parallelism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8595,7 +8595,7 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "resolved": false,
           "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "dev": true
         },
@@ -8942,7 +8942,7 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true
         },
@@ -9503,7 +9503,7 @@
         },
         "glob": {
           "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "resolved": false,
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
@@ -9602,7 +9602,7 @@
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "resolved": false,
           "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
           "dev": true
         },
@@ -9758,7 +9758,7 @@
         },
         "is-ci": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "resolved": false,
           "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "dev": true,
           "requires": {
@@ -9845,7 +9845,7 @@
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
           "dev": true
         },
@@ -10425,7 +10425,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "resolved": false,
               "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true
             }
@@ -10484,7 +10484,7 @@
         },
         "node-gyp": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
           "dev": true,
           "requires": {
@@ -10610,7 +10610,7 @@
         },
         "npm-packlist": {
           "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+          "resolved": false,
           "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "dev": true,
           "requires": {
@@ -10632,7 +10632,7 @@
         },
         "npm-profile": {
           "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
           "dev": true,
           "requires": {
@@ -11134,7 +11134,7 @@
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "requires": {
@@ -11146,7 +11146,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "resolved": false,
               "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true
             }
@@ -11211,7 +11211,7 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": false,
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
@@ -11234,7 +11234,7 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "dev": true,
           "requires": {
@@ -11305,7 +11305,7 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "resolved": false,
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
@@ -11644,7 +11644,7 @@
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": false,
           "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
@@ -11653,7 +11653,7 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+              "resolved": false,
               "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
               "dev": true
             }
@@ -12006,7 +12006,7 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "dev": true,
           "requires": {
@@ -12591,7 +12591,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -12633,8 +12632,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-hash": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
   },
   "dependencies": {
     "@adobe/fastly-native-promises": "1.16.0",
-    "@adobe/helix-fetch": "1.6.1",
     "@adobe/helix-epsagon": "1.3.7",
+    "@adobe/helix-fetch": "1.6.1",
     "@adobe/helix-log": "4.5.1",
     "@adobe/helix-shared": "7.4.0",
     "@adobe/helix-status": "7.1.3",
@@ -91,6 +91,7 @@
     "@adobe/openwhisk-action-utils": "4.2.2",
     "fs-extra": "9.0.0",
     "glob-to-regexp": "0.4.1",
+    "p-limit": "^2.3.0",
     "uri-js": "4.2.2"
   },
   "config": {

--- a/src/fastly/dictionaries.js
+++ b/src/fastly/dictionaries.js
@@ -9,7 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+const promiseLimit = require('p-limit');
 const { regexp } = require('./vcl-utils');
+
+const limit = promiseLimit(2);
 
 const dictionaries = [
   'secrets',
@@ -76,7 +79,7 @@ async function updatestrains(fastly, version, strains) {
   }, {});
 
   const updates = Object.entries(strainoperations).reduce((p, [dictname, operations]) => {
-    p.push(fastly.bulkUpdateDictItems(version, dictname, ...operations));
+    p.push(limit(() => fastly.bulkUpdateDictItems(version, dictname, ...operations)));
     return p;
   }, []);
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -18,6 +18,31 @@ const dictionaries = require('./fastly/dictionaries');
 const redirects = require('./fastly/redirects');
 const epsagon = require('./fastly/epsagon');
 const checkPkgs = require('./check-pkgs');
+
+function reportError(e) {
+  if (e.cause && e.cause.code
+    && (e.cause.code === 'ESOCKETTIMEDOUT'
+    || e.cause.code === 'ETIMEDOUT')
+  ) {
+    return {
+      body: {
+        status: 'error',
+        message: `timeout ${e}`,
+        stack: e.stack.split('\n'),
+      },
+      statusCode: 504,
+    };
+  }
+  return {
+    body: {
+      status: 'error',
+      message: `${e}`,
+      stack: e.stack.split('\n'),
+    },
+    statusCode: 500,
+  };
+}
+
 /**
  *
  * @param {object} configuration the Helix Strains configuration
@@ -96,24 +121,7 @@ async function publish(configuration, service, token, version, vclOverrides = {}
       })
       .catch((e) => {
         log.error(`error executing tasks: ${e}, ${e.data}`, e);
-        if (e.cause && e.cause.code && e.cause.code === 'ESOCKETTIMEDOUT') {
-          return {
-            body: {
-              status: 'error',
-              message: `${e}`,
-              stack: e.stack.split('\n'),
-            },
-            statusCode: 504,
-          };
-        }
-        return {
-          body: {
-            status: 'error',
-            message: `${e}`,
-            stack: e.stack.split('\n'),
-          },
-          statusCode: 500,
-        };
+        return reportError(e);
       });
   } catch (e) {
     // invalid configuration
@@ -130,3 +138,4 @@ async function publish(configuration, service, token, version, vclOverrides = {}
 }
 
 module.exports = publish;
+module.exports.reportError = reportError;

--- a/src/publish.js
+++ b/src/publish.js
@@ -96,6 +96,16 @@ async function publish(configuration, service, token, version, vclOverrides = {}
       })
       .catch((e) => {
         log.error(`error executing tasks: ${e}, ${e.data}`, e);
+        if (e.cause && e.cause.code && e.cause.code === 'ESOCKETTIMEDOUT') {
+          return {
+            body: {
+              status: 'error',
+              message: `${e}`,
+              stack: e.stack.split('\n'),
+            },
+            statusCode: 504,
+          };
+        }
         return {
           body: {
             status: 'error',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+const assert = require('assert');
+const { reportError } = require('../src/publish');
+
+describe('Error reporting tests', () => {
+  it('Reports generic errors as 500', () => {
+    try {
+      throw new Error();
+    } catch (error) {
+      const res = reportError(error);
+      assert.equal(res.statusCode, 500);
+    }
+  });
+
+  it('Reports timeout errors as 504', () => {
+    try {
+      const e = new Error();
+      e.cause = {
+        code: 'ESOCKETTIMEDOUT',
+      };
+      throw e;
+    } catch (error) {
+      const res = reportError(error);
+      assert.equal(res.statusCode, 504);
+    }
+  });
+});


### PR DESCRIPTION
I've experienced timeout errors when updating dictionaries due to node's limited DNS pool. This PR reports timeouts as 504 and prevents them.

before:  https://dashboard.epsagon.com/spans/0e7959ea-a1ea-54d6-f27d-4c3ecd6b2857?tab=timeline
after: https://dashboard.epsagon.com/spans/0e795a70-0b38-eeca-de75-9359f9de0283?tab=timeline