### PR TITLE
fix(vcl): do not enforce default branch

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -266,9 +266,9 @@ sub hlx_ref {
   if (!req.http.X-Ref) {
     set req.http.X-Ref = table.lookup(strain_refs, "default");
   }
-  # if default isn't set, use 'master'
+  # if default isn't set, use nothing and hope that helix-resolve-git-ref will pick the correct default branch
   if (!req.http.X-Ref) {
-    set req.http.X-Ref = "master";
+    set req.http.X-Ref = "";
   }
 
   call hlx_ref_after;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12600,7 +12600,6 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
       "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }


### PR DESCRIPTION
this should allow us to support main and master, assuming helix-resolve-git-ref is used consistently downstream

fixes #617 
depends on #626

**Needs testing with helix-pages**