### PR TITLE
feat(deps): use content-proxy v2

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1085,7 +1085,7 @@ sub hlx_type_content {
 
   set req.http.X-Backend-URL = "/api/v1/web"
     + "/" + var.namespace // i.e. /trieloff
-    + "/helix-services/content-proxy@v1"
+    + "/helix-services/content-proxy@v2"
     + "?ref=" + var.ref
     + "&path=" + req.url.path
     // content repo


### PR DESCRIPTION
BREAKING CHANGE: content proxy v2 uses new data embed and gdocs services.
                 - requests to json now returns an object instead of and array [0]
                 - gdocs2md now has a different table handling [1]
                 - gdocs2md supports author friendly names [2]

[0] https://github.com/adobe/helix-data-embed/commit/9d1e924acc3aa6488b464a3cdc4a3bf68e3843bc
[1] https://github.com/adobe/helix-gdocs2md/commit/e4befdbaed4a5319b2cca4be8507f153bedcc68a
[2] https://github.com/adobe/helix-gdocs2md/commit/3aca7b387bbee977f84e61ce823ff6271b1b0a8d
