### PR TITLE
fix: allow table and sheet as parameters

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1081,7 +1081,7 @@ sub hlx_type_content {
   }
 
   // clean up the query string
-  set req.url = querystring.regfilter_except(req.url, "^(limit|offset|hlx_.*)$");
+  set req.url = querystring.regfilter_except(req.url, "^(limit|offset|table|sheet|hlx_.*)$");
 
   set req.http.X-Backend-URL = "/api/v1/web"
     + "/" + var.namespace // i.e. /trieloff


### PR DESCRIPTION
fix #632 