### PR TITLE
fix(backends): always set sni hostname for runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "nyc --reporter=text --reporter=lcov --check-coverage --statements 99 --lines 99 mocha",
-    "test-ci": "nyc --reporter=text --reporter=lcov --check-coverage --statements 99 --lines 99 mocha --reporter xunit --reporter-options output=./junit/test-results.xml -i -g 'Post-Deploy' && codecov",
+    "test-ci": "nyc --reporter=text --reporter=lcov --check-coverage --statements 99 --lines 99 mocha --reporter-options output=./junit/test-results.xml -i -g 'Post-Deploy' && codecov",
     "lint": "./node_modules/.bin/eslint .",
     "junit": "mocha --exit -R mocha-junit-reporter",
     "test-postdeploy": "mocha --reporter xunit --reporter-options output=./junit/test-results.xml -g 'Post-Deploy'",

--- a/src/check-pkgs.js
+++ b/src/check-pkgs.js
@@ -10,7 +10,11 @@
  * governing permissions and limitations under the License.
  */
 /* eslint-disable max-classes-per-file */
-const { fetch } = require('@adobe/helix-fetch');
+const { fetch } = require('@adobe/helix-fetch').context({
+  httpsProtocols:
+  /* istanbul ignore next */
+    process.env.HELIX_FETCH_FORCE_HTTP1 ? ['http1'] : ['http2', 'http1'],
+});
 
 /**
  * This function takes strains and sends requests

--- a/src/fastly/backends.js
+++ b/src/fastly/backends.js
@@ -40,6 +40,7 @@ const backends = {
     between_bytes_timeout: 10000,
     shield: 'bwi-va-us',
     ssl_cert_hostname: 'adobeioruntime.net',
+    ssl_sni_hostname: 'adobeioruntime.net',
     max_conn: 200,
     use_ssl: true,
   },


### PR DESCRIPTION
because fastly suddenly requires it? or something changed with the cert?

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
