### PR TITLE
fix(preflight): version lock is lost after preflight

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -330,7 +330,7 @@ sub hlx_github_static_root {
 # Gets the version lock
 sub hlx_version_lock {
   set req.http.X-Trace = req.http.X-Trace + "; hlx_version_lock";
-  if (req.http.X-OW-Version-Lock) {
+  if (req.http.X-OW-Version-Lock && req.http.X-OW-Version-Lock != "") {
     set req.http.X-Trace = req.http.X-Trace + "(header)";
     return;
   }


### PR DESCRIPTION
fixes #673


