### PR TITLE
fix(block): block invalid URL-code sequences

### DIFF
--- a/src/rgx/block.js
+++ b/src/rgx/block.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 module.exports = [
+  /%([^0-9A-Fa-f]($|[^0-9A-Fa-f])|[0-9A-Fa-f][^0-9A-Fa-f])/,
   /_debugbar/,
   /.+\.axd/,
   /.+\.log$/,

--- a/test/fixtures/blocked-paths.txt
+++ b/test/fixtures/blocked-paths.txt
@@ -2105,3 +2105,4 @@
 /zookeeper.log
 /en/publish/2017/07/25/adobe-flash-update.html%gs.n7ri0q
 /libs/cq/analytics/templates/sitecatalyst/jcr:content.segments.json/a.1.json?datacenter=http://6.vtshd4yl3tidttqc2mbhqu2krbx2zqo.blog.adobe.com.x.bughunty.tk%23&company=xxx&username=zzz&secret=yyyy
+/en/fpost/2020/update-for-enterprise-adobe-flash-player.html%gs.o60v58


### PR DESCRIPTION
any URL code sequence of a % that is not followed by two hex digits will be rejeceted by Adobe I/O Runtime Gateway with a 500. This change rejects it already at the CDN level.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
