### PR TITLE
Support .hlx virtual resources to allow rootless setups

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -830,6 +830,12 @@ sub hlx_type_query {
     set var.qindex_version = {"const:query-index_version"};
   }
 
+  # Only declare local variables for things we mean to change before putting
+  # them into the URL
+  declare local var.universal BOOL;   # use universal runtime?
+  declare local var.hostname STRING;  # if yes, what's the hostname
+  declare local var.namespace STRING; # namespace
+  
   # We need the action root for the next bit
   call hlx_action_root;
 
@@ -846,11 +852,7 @@ sub hlx_type_query {
   }
 
   if (req.url.path ~ "(^/_query|/query\.hlx/)/([^/]+)\/([^/]+)$") {
-    # Only declare local variables for things we mean to change before putting
-    # them into the URL
-    declare local var.universal BOOL;   # use universal runtime?
-    declare local var.hostname STRING;  # if yes, what's the hostname
-    declare local var.namespace STRING; # namespace
+
 
 
     # establish the fallback first

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -472,13 +472,13 @@ sub hlx_determine_request_type {
   }
 
   // something like /cgi-bin/foo.js or /cgi-bin/bar.cgi
-  if (req.url.dirname ~ "^/cgi-bin" || req.url.dirname ~ "/cgi-bin.hlx") {
+  if (req.url.dirname ~ "^/cgi-bin" || req.url.dirname ~ "/cgi-bin\.hlx") {
     set req.http.X-Request-Type = "CGI-Action";
     return;
   }
 
   // something like /_query/index/name
-  if (req.url.path ~ "^/_query/.+/.+$") {
+  if (req.url.path ~ "^/_query/.+/.+$" || req.url.path ~ "^/query\.hlx/.+/.+$") {
     set req.http.X-Trace = req.http.X-Trace + "(query)";
     set req.http.X-Request-Type = "Query";
     unset req.http.Accept-Encoding;
@@ -830,31 +830,33 @@ sub hlx_type_query {
     set var.qindex_version = {"const:query-index_version"};
   }
 
-  if (req.url.path ~ "^/_query/([^/]+)\/([^/]+)$") {
+  # We need the action root for the next bit
+  call hlx_action_root;
+
+  if (req.http.X-Action-Root ~ "(^|^https://)([^/:\.]+)(/|\.([^/]+)/)([^/]+)") {
+    set var.universal = false;
+    set var.namespace = re.group.2;
+
+    if(re.group.1 == "https://") {
+      set var.universal = true;
+      set var.hostname = var.namespace + "." + re.group.4;
+      set req.backend = F_UniversalRuntime;
+      set req.http.X-Backend-Host = var.hostname;
+    }
+  }
+
+  if (req.url.path ~ "(^/_query|/query\.hlx/)/([^/]+)\/([^/]+)$") {
     # Only declare local variables for things we mean to change before putting
     # them into the URL
     declare local var.universal BOOL;   # use universal runtime?
     declare local var.hostname STRING;  # if yes, what's the hostname
     declare local var.namespace STRING; # namespace
 
-    # We need the action root for the next bit
-    call hlx_action_root;
 
-    if (req.http.X-Action-Root ~ "(^|^https://)([^/:\.]+)(/|\.([^/]+)/)([^/]+)") {
-      set var.universal = false;
-      set var.namespace = re.group.2;
-
-      if(re.group.1 == "https://") {
-        set var.universal = true;
-        set var.hostname = var.namespace + "." + re.group.4;
-        set req.backend = F_UniversalRuntime;
-        set req.http.X-Backend-Host = var.hostname;
-      }
-    }    
     # establish the fallback first
     set req.http.X-Backend-URL = if(var.universal, "/", "/api/v1/web" + "/" + var.namespace)
     + "/helix-services/query-index@" + var.qindex_version
-    + "/" + re.group.1 + "/" + re.group.2
+    + "/" + re.group.2 + "/" + re.group.3
     + "?__hlx_owner=" + req.http.X-Owner
     + "&__hlx_repo=" + req.http.X-Repo
     + "&__hlx_ref=" + req.http.X-Ref

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -464,7 +464,7 @@ sub hlx_determine_request_type {
   }
 
   // something like https://hlx.blob.core.windows.net/external/098af326aa856bb42ce9a21240cf73d6f64b0b45
-  if (req.url.path ~ "^/(hlx_([0-9a-f]){40}).([0-9a-z]+)$") {
+  if (req.url.path ~ "^/(hlx_([0-9a-f]){40}).([0-9a-z]+)$" || req.url.path ~ "/blob\.hlx/([0-9a-f]){40}\.([0-9a-z]+)$") {
     set req.http.X-Trace = req.http.X-Trace + "(blob)";
     set req.http.X-Request-Type = "Blob";
     unset req.http.Accept-Encoding;
@@ -797,8 +797,8 @@ sub hlx_type_blob {
   declare local var.ext STRING;
   declare local var.sas STRING;
 
-  if (req.url.path ~ "^/hlx_(([0-9a-f]){40}).([0-9a-z]+)$") {
-    set var.sha = re.group.1;
+  if (req.url.path ~ "(^/hlx_|/blob\.hlx/)(([0-9a-f]){40}).([0-9a-z]+)$") {
+    set var.sha = re.group.2;
     set var.ext = req.url.ext;
     set var.sas = table.lookup(secrets, "AZURE_BLOB_SAS_RO", "");
 

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -501,7 +501,10 @@ sub hlx_determine_request_type {
 
   // something like /hlx_fonts/af/d91a29/00000000000000003b9af759/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i4&v=3
   // but not like /hlx_fonts/eic8tkf.css
-  if (req.url.path ~ "^/hlx_fonts/.+" && req.url.ext != "css") {
+  // or
+  // something like /foo/fonts.hlx/af/d91a29/00000000000000003b9af759/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i4&v=3
+  // but not like /foo/fonts.hlx/eic8tkf.css
+  if (req.url.path ~ "(^/hlx_fonts|/fonts\.hlx)/.+" && req.url.ext != "css") {
     set req.http.X-Trace = req.http.X-Trace + "(fonts)";
     set req.http.X-Request-Type = "Fonts";
   }
@@ -835,7 +838,7 @@ sub hlx_type_query {
   declare local var.universal BOOL;   # use universal runtime?
   declare local var.hostname STRING;  # if yes, what's the hostname
   declare local var.namespace STRING; # namespace
-  
+
   # We need the action root for the next bit
   call hlx_action_root;
 
@@ -884,7 +887,8 @@ sub hlx_type_fonts {
   set req.backend = F_AdobeFonts;
 
   # remove the /hlx_fonts/ prefix again
-  set req.http.X-Backend-URL = regsub(req.url, "^/hlx_fonts/", "/");
+  # or everything before and including /fonts.hlx
+  set req.http.X-Backend-URL = regsub(req.url, "(^/hlx_fonts|^.*/fonts.hlx)/", "/");
 
   unset req.http.x-forwarded-host;
 }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -472,7 +472,7 @@ sub hlx_determine_request_type {
   }
 
   // something like /cgi-bin/foo.js or /cgi-bin/bar.cgi
-  if (req.url.dirname ~ "^/cgi-bin?") {
+  if (req.url.dirname ~ "^/cgi-bin" || req.url.dirname ~ "/cgi-bin.hlx") {
     set req.http.X-Request-Type = "CGI-Action";
     return;
   }


### PR DESCRIPTION
See https://github.com/adobe/fedpub/issues/12 when running Helix Pages at a non-root location behind a CDN, all our `/_hlx/…` resources are broken because they are at an inaccessible path.

This PR will introduce a set of `*.hlx` virtual resources that work at any path depth

- Images from Word and Google will be at `/foo/blob.hlx/79f1216a4ab875f5d4a7f6e2ab77cc337700bf.png`
- CGI-BIN will be at `/foo/cgi-bin.hlx/scriptname.pl`
- Queries will be at `/foo/query.hlx/indexname/queryname`
- Fonts will be at `/foo/fonts.hlx/4odo83.css`

Related:
- adobe/helix-static#485: makes sure Typekit CSS looks correct and uses relative paths
- adobe/helix-pipeline#955: makes sure the pipeline creates relative image links