### PR TITLE
fix(vcl): allow setting request type from outside

### DIFF
--- a/src/fastly/vcl-utils.js
+++ b/src/fastly/vcl-utils.js
@@ -123,7 +123,7 @@ function resolve(mystrains, preflight) {
 # Strain resolution depends on preflight completion. If the preflight request has
 # not been made, we need to start it now.
 
-if (req.restarts < 1) {
+if (req.restarts < 1 && !req.http.X-Request-Type) {
   set req.http.X-Request-Type = "Preflight";
 } else {
 `;


### PR DESCRIPTION
for configs that used preflight conditions (like helix-pages), the request type would be reset every time, breaking a crucial smoke test. This change restores the previous behavior

see https://github.com/adobe/helix-pages/issues/671

