### PR TITLE
fix(preflight): do not process preflight requests for external embeds

### DIFF
--- a/src/fastly/vcl-utils.js
+++ b/src/fastly/vcl-utils.js
@@ -123,7 +123,7 @@ function resolve(mystrains, preflight) {
 # Strain resolution depends on preflight completion. If the preflight request has
 # not been made, we need to start it now.
 
-if (req.restarts < 1 && !req.http.X-Request-Type) {
+if (req.restarts < 1 && !req.http.X-Request-Type && req.http.host != "adobeioruntime.net") {
   set req.http.X-Request-Type = "Preflight";
 } else {
 `;


### PR DESCRIPTION
The `embed` request type is quite different from other request types, as it goes to a different host, so the typical method of determining owner, repo, ref does not work. On the other hand, the underlying service does not make use of strains at all, so there is litte point in trying to resolve a strain. This change will skip preflight requests for embeds. A side effect is that the version-picker for helix-embed won't work for users in helix-pages.

fixes #725

