### PR TITLE
feat(strains): allow strain selection via x-stealthy-strain header

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -168,7 +168,7 @@ sub hlx_strain {
     set req.http.X-Trace = req.http.X-Trace + "(cookie)";
   }
   # read strain from stealty-strain header
-  if (req.http.X-Stealty-Strain) {
+  if (req.http.X-Stealthy-Strain) {
     set req.http.X-Strain = req.http.X-Stealthy-Strain;
     set req.http.X-Trace = req.http.X-Trace + "(stealthy)";
   }

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -167,6 +167,11 @@ sub hlx_strain {
     set req.http.X-Strain = req.http.Cookie:X-Strain;
     set req.http.X-Trace = req.http.X-Trace + "(cookie)";
   }
+  # read strain from stealty-strain header
+  if (req.http.X-Stealty-Strain) {
+    set req.http.X-Strain = req.http.X-Stealthy-Strain;
+    set req.http.X-Trace = req.http.X-Trace + "(stealthy)";
+  }
 
   # Sanitize user input. `urlencode` leaves alphanumeric and `-._~`
   set req.http.X-Strain = regsuball(urlencode(req.http.X-Strain), {"%.."}, "_");


### PR DESCRIPTION
other than the explicit selection via the x-strain header, this one does not affect the cachability. This also means that changes to x-stealty-strain will only become effective once the cache has expired

see https://github.com/adobe/helix-pages/pull/695#issuecomment-781187574
