### PR TITLE
feat(sitemap): serve sitemap.xml from content proxy

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -504,7 +504,7 @@ sub hlx_determine_request_type {
     return;
   }
 
-  if (req.url.ext ~ "^xml$" && req.url.path ~ "^/sitemap\.") {
+  if (req.url.path ~ "/sitemap(-[^/]+)?\.xml$") {
     set req.http.X-Trace = req.http.X-Trace + "(content-sitemap)";
     set req.http.X-Request-Type = "Content/Sitemap";
     return;

--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -504,6 +504,12 @@ sub hlx_determine_request_type {
     return;
   }
 
+  if (req.url.ext ~ "^xml$" && req.url.path ~ "^/sitemap\.") {
+    set req.http.X-Trace = req.http.X-Trace + "(content-sitemap)";
+    set req.http.X-Request-Type = "Content/Sitemap";
+    return;
+  }
+
   // something like /hlx_fonts/af/d91a29/00000000000000003b9af759/27/l?primer=34645566c6d4d8e7116ebd63bd1259d4c9689c1a505c3639ef9e73069e3e4176&fvd=i4&v=3
   // but not like /hlx_fonts/eic8tkf.css
   if (req.url.path ~ "^/hlx_fonts/.+" && req.url.ext != "css") {
@@ -1628,6 +1634,8 @@ sub vcl_recv {
   } elseif (req.http.X-Request-Type == "Content/MD") {
     call hlx_type_content;
   } elseif (req.http.X-Request-Type == "Content/JSON") {
+    call hlx_type_content;
+  } elseif (req.http.X-Request-Type == "Content/Sitemap") {
     call hlx_type_content;
   } elseif (req.http.X-Request-Type == "Preflight") {
     call hlx_type_preflight;


### PR DESCRIPTION
sitemaps should be served as content binaries

BREAKING CHANGE: fixes #783 depends on adobe/helix-content-proxy#315 – breaks sitemap serving for sites that serve `/` from Google or Word and have their sitemap only on GitHub. You either need to copy the `sitemap.xml` to your content repository (recommended) or create a `helix-fstab.yaml` entry for the sitemap to continue serving it from GitHub (this time via content proxy instead of static)
