### PR TITLE
fix(vcl): fix 401 to 500 propagation, propagate as 403 instead

### DIFF
--- a/layouts/fastly/helix.vcl
+++ b/layouts/fastly/helix.vcl
@@ -1270,6 +1270,10 @@ sub hlx_fetch_error {
       error 965 "Too many requests";
     } elsif (beresp.status == 400) {
       error 966 "Bad request";
+    } elsif (beresp.status == 401) {
+      // we handle a 401 from the backend just like a 403, as there won't be any
+      // chance that the client can re-authenticate.
+      error 955 "Forbidden";
     } else {
        error 952 "Internal Server Error";
     }


### PR DESCRIPTION
a 401 from the backend was unhandled so far (500), now we propagate it as a 403 (Forbidden) instead of 401 (Unauthorized) as a 401 would ask the browser for credentials (HTTP Basic Auth) that we do not want to handle anyway.

fixes #893
